### PR TITLE
Tweak display of FeatureCollection layers

### DIFF
--- a/Toolkit/ArcGISToolkit/LegendViewController.swift
+++ b/Toolkit/ArcGISToolkit/LegendViewController.swift
@@ -310,7 +310,16 @@ public class LegendViewController: UIViewController, UITableViewDelegate, UITabl
             
             // if we're showing the layerContent, add it to our legend array
             if showAtScale {
-                legendArray.append(layerContent)
+                if let featureCollectionLayer = layerContent as? AGSFeatureCollectionLayer {
+                    // only show Feature Collection layer if the sublayer count is > 1
+                    // but always show the sublayers (the call to `updateLayerLegend`)
+                    if featureCollectionLayer.layers.count > 1 {
+                        legendArray.append(layerContent)
+                    }
+                }
+                else {
+                    legendArray.append(layerContent)
+                }
                 updateLayerLegend(layerContent)
             }
         }


### PR DESCRIPTION
This will fix the issue with duplicate layer names appearing for Feature Collection layers with only one sublayer.  For FC layers with more than one sublayer there will be no change