### PR TITLE
Uses proper Swift names for UITableViewDelegate methods.

### DIFF
--- a/Examples/ArcGISToolkitExamples/JobManagerExample.swift
+++ b/Examples/ArcGISToolkitExamples/JobManagerExample.swift
@@ -210,7 +210,7 @@ class JobManagerExample: TableViewController {
         return cell
     }
     
-    open func tableView(_ tableView: UITableView, didSelectRowAtIndexPath indexPath: IndexPath) {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
     }
     

--- a/Examples/ArcGISToolkitExamples/VCListViewController.swift
+++ b/Examples/ArcGISToolkitExamples/VCListViewController.swift
@@ -43,14 +43,14 @@ open class VCListViewController: TableViewController {
     
     override open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: cellReuseIdentifier)!
-        cell.textLabel?.text = viewControllerInfos[(indexPath as NSIndexPath).row].vcName
+        cell.textLabel?.text = viewControllerInfos[indexPath.row].vcName
         return cell
     }
     
-    open func tableView(_ tableView: UITableView, didSelectRowAtIndexPath indexPath: IndexPath) {
+    public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         
-        let t = viewControllerInfos[(indexPath as NSIndexPath).row].viewControllerType
-        let nibName = viewControllerInfos[(indexPath as NSIndexPath).row].nibName
+        let t = viewControllerInfos[indexPath.row].viewControllerType
+        let nibName = viewControllerInfos[indexPath.row].nibName
         var vcOpt : UIViewController? = nil
         
         // first check storyboard

--- a/Toolkit/ArcGISToolkit/UnitsViewController.swift
+++ b/Toolkit/ArcGISToolkit/UnitsViewController.swift
@@ -215,7 +215,7 @@ public class UnitsViewController: TableViewController, UINavigationBarDelegate, 
     
     // MARK: TableView delegate/datasource methods
     
-    func tableView(_ tableView: UITableView, didSelectRowAtIndexPath indexPath: IndexPath) {
+    public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         // when the user taps on a unit
         //
 


### PR DESCRIPTION
Also removes unnecessary casts to NSIndexPath.