### PR TITLE
Fix deprecated warnings

### DIFF
--- a/Examples/ArcGISToolkitExamples/Info.plist
+++ b/Examples/ArcGISToolkitExamples/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>100.4</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/Toolkit/ArcGISToolkit/Info.plist
+++ b/Toolkit/ArcGISToolkit/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>100.4</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Toolkit/ArcGISToolkit/MeasureToolbar.swift
+++ b/Toolkit/ArcGISToolkit/MeasureToolbar.swift
@@ -318,7 +318,7 @@ public class MeasureToolbar: UIToolbar, AGSGeoViewTouchDelegate {
         
         // defaults for symbology
         selectionLineSymbol = lineSketchEditor.style.lineSymbol
-        selectionColor = lineSketchEditor.style.selectionColor
+        selectionColor = mapView?.selectionProperties.color
         let fillColor = (selectionColor ?? UIColor.cyan).withAlphaComponent(0.25)
         let sfs = AGSSimpleFillSymbol(style: .solid, color: fillColor, outline: selectionLineSymbol as? AGSSimpleLineSymbol)
         selectionFillSymbol = sfs
@@ -329,7 +329,9 @@ public class MeasureToolbar: UIToolbar, AGSGeoViewTouchDelegate {
         
         if let mapView = mapView{
             let selectionOverlay = AGSGraphicsOverlay()
-            selectionOverlay.selectionColor = selectionColor
+            if let selectionColor = selectionColor {
+                mapView.selectionProperties.color = selectionColor
+            }
             self.selectionOverlay = selectionOverlay
             mapView.graphicsOverlays.add(selectionOverlay)
             

--- a/Toolkit/ArcGISToolkit/MeasureToolbar.swift
+++ b/Toolkit/ArcGISToolkit/MeasureToolbar.swift
@@ -174,8 +174,11 @@ public class MeasureToolbar: UIToolbar, AGSGeoViewTouchDelegate {
     // Exposed so that the symbology and selection colors can be customized.
     public private(set) var selectionLineSymbol : AGSSymbol?
     public private(set)var selectionFillSymbol : AGSSymbol?
-    public private(set) var selectionColor : UIColor?
-    
+    @available(iOS, deprecated, message: "Use `color` property exposed through `AGSGeoView#selectionProperties`")
+    public var selectionColor : UIColor? {
+        return mapView?.selectionProperties.color
+    }
+
     public var mapView : AGSMapView? {
         didSet{
             guard mapView != oldValue else { return }
@@ -322,8 +325,7 @@ public class MeasureToolbar: UIToolbar, AGSGeoViewTouchDelegate {
         if let mapView = mapView{
             // defaults for symbology
             selectionLineSymbol = lineSketchEditor.style.lineSymbol
-            selectionColor = mapView.selectionProperties.color
-            let fillColor = (selectionColor ?? UIColor.cyan).withAlphaComponent(0.25)
+            let fillColor = mapView.selectionProperties.color.withAlphaComponent(0.25)
             let sfs = AGSSimpleFillSymbol(style: .solid, color: fillColor, outline: selectionLineSymbol as? AGSSimpleLineSymbol)
             selectionFillSymbol = sfs
             

--- a/Toolkit/ArcGISToolkit/MeasureToolbar.swift
+++ b/Toolkit/ArcGISToolkit/MeasureToolbar.swift
@@ -313,25 +313,21 @@ public class MeasureToolbar: UIToolbar, AGSGeoViewTouchDelegate {
         selectModeButtons = [segControlItem, leftHiddenPlaceholderButton, flexButton, rightHiddenPlaceholderButton]
         
         // notification
-        
         NotificationCenter.default.addObserver(self, selector: #selector(sketchEditorGeometryDidChange(_:)), name: .AGSSketchEditorGeometryDidChange, object: nil)
-        
-        // defaults for symbology
-        selectionLineSymbol = lineSketchEditor.style.lineSymbol
-        selectionColor = mapView?.selectionProperties.color
-        let fillColor = (selectionColor ?? UIColor.cyan).withAlphaComponent(0.25)
-        let sfs = AGSSimpleFillSymbol(style: .solid, color: fillColor, outline: selectionLineSymbol as? AGSSimpleLineSymbol)
-        selectionFillSymbol = sfs
     }
     
     private func bindToMapView(mapView: AGSMapView?){
         mapView?.touchDelegate = self
         
         if let mapView = mapView{
+            // defaults for symbology
+            selectionLineSymbol = lineSketchEditor.style.lineSymbol
+            selectionColor = mapView.selectionProperties.color
+            let fillColor = (selectionColor ?? UIColor.cyan).withAlphaComponent(0.25)
+            let sfs = AGSSimpleFillSymbol(style: .solid, color: fillColor, outline: selectionLineSymbol as? AGSSimpleLineSymbol)
+            selectionFillSymbol = sfs
+            
             let selectionOverlay = AGSGraphicsOverlay()
-            if let selectionColor = selectionColor {
-                mapView.selectionProperties.color = selectionColor
-            }
             self.selectionOverlay = selectionOverlay
             mapView.graphicsOverlays.add(selectionOverlay)
             

--- a/Toolkit/ArcGISToolkit/MeasureToolbar.swift
+++ b/Toolkit/ArcGISToolkit/MeasureToolbar.swift
@@ -174,7 +174,7 @@ public class MeasureToolbar: UIToolbar, AGSGeoViewTouchDelegate {
     // Exposed so that the symbology and selection colors can be customized.
     public private(set) var selectionLineSymbol : AGSSymbol?
     public private(set)var selectionFillSymbol : AGSSymbol?
-    @available(iOS, deprecated, message: "Use `color` property exposed through `AGSGeoView#selectionProperties`")
+    @available(iOS, deprecated, message: "Use `color` property exposed through `AGSGeoView.selectionProperties`")
     public var selectionColor : UIColor? {
         return mapView?.selectionProperties.color
     }


### PR DESCRIPTION
This fixes two "deprecated" warnings when building against the v100.4 SDK.  The selection color property now lives on the `selectionProperties` property of `AGSMapView`.

The code to initialize the symbols with the selection color was moved to the `bindToMapView` method from the `sharedInitialization` method.  That is because at the time `sharedInitialization` is called, the `mapView` property hasn't been initialized yet, so the `mapView.selectionProperties.color` property will always be nil.