### PR TITLE
Add NSCameraUsageDescription

### DIFF
--- a/Examples/ArcGISToolkitExamples/Info.plist
+++ b/Examples/ArcGISToolkitExamples/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSCameraUsageDescription</key>
+	<string>For collecting attachments in popups</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>For collecting attachments in popups</string>
 	<key>CFBundleDevelopmentRegion</key>


### PR DESCRIPTION
Add NSCameraUsageDescription to Example App's Info.plist.  This fixes a crash when adding an attachment and accessing the camera in the Popup Example/