### PR TITLE
Mhd/transformation matrix camera controller

### DIFF
--- a/Toolkit/ArcGISToolkit/AR/ArcGISARView.swift
+++ b/Toolkit/ArcGISToolkit/AR/ArcGISARView.swift
@@ -68,18 +68,17 @@ public class ArcGISARView: UIView {
     /// The viewpoint camera used to set the initial view of the sceneView instead of the devices GPS location via the locationManager.
     public var originCamera: AGSCamera? {
         didSet {
-            if let newCamera = originCamera {
-                // Set the camera as the originCamera on the cameraController and reset tracking.
-                cameraController.originCamera = newCamera
-                resetTracking()
-            }
+            guard let newCamera = originCamera else { return }
+            // Set the camera as the originCamera on the cameraController and reset tracking.
+            cameraController.originCamera = newCamera
+            resetTracking()
         }
     }
     
     /// The translation factor used to support a table top AR experience.
     public var translationTransformationFactor: Double = 1.0
     
-    /// We implement ARSCNViewDelegate methods, but will use `arSCNViewDelegate` to forward them to clients.
+    /// We implement `ARSCNViewDelegate` methods, but will use `arSCNViewDelegate` to forward them to clients.
     weak open var arSCNViewDelegate: ARSCNViewDelegate?
 
     // MARK: private properties
@@ -198,7 +197,7 @@ public class ArcGISARView: UIView {
             return
         }
         
-        if let _ = originCamera {
+        if originCamera != nil {
             // We have a starting camera, so no need to start the location manager, just finalizeStart().
             finalizeStart()
         }

--- a/Toolkit/ArcGISToolkit/AR/ArcGISARView.swift
+++ b/Toolkit/ArcGISToolkit/AR/ArcGISARView.swift
@@ -111,7 +111,7 @@ public class ArcGISARView: UIView {
     /// Used when calculating framerate.
     private var lastUpdateTime: TimeInterval = 0
     
-    /// A quaternion used to compensate for the pitch beeing 90 degrees on `ARKit`; used to calculate the current device transformation for each frame.
+    /// A quaternion used to compensate for the pitch being 90 degrees on `ARKit`; used to calculate the current device transformation for each frame.
     private let compensationQuat: simd_quatd = simd_quatd(ix: (sin(45 / (180 / .pi))), iy: 0, iz: 0, r: (cos(45 / (180 / .pi))))
     
     // MARK: Initializers


### PR DESCRIPTION
The new `AGSTransformationMatrixCameraController` is now used to control the camera in the `AGSSceneView`, which simplifies the math quite a bit.  Also, the deviceOrientation code is no longer necessary and is removed, which gets rid of the `orientationChanged` notification as well.

Use the new `spaceEffect` property on an `AGSSceneView` instead of `isBackgroundTransparent`.