### PR TITLE
JobManager clean up

### DIFF
--- a/Toolkit/ArcGISToolkit/JobManager.swift
+++ b/Toolkit/ArcGISToolkit/JobManager.swift
@@ -234,6 +234,8 @@ public class JobManager: NSObject {
     
     /// Resume all paused and not-started jobs.
     public func resumeAllPausedJobs(statusHandler: @escaping JobStatusHandler, completion: @escaping JobCompletionHandler) {
+        // Note that a job is also paused if it is created from JSON. So any jobs that have been stored in
+        // UserDefaults and reloaded will be in the paused state.
         keyedJobs.filter({ $0.value.status == .paused || $0.value.status == .notStarted }).forEach {
             $0.value.start(statusHandler: statusHandler, completion:completion)
         }

--- a/Toolkit/ArcGISToolkit/JobManager.swift
+++ b/Toolkit/ArcGISToolkit/JobManager.swift
@@ -91,7 +91,7 @@ public class JobManager: NSObject {
     }
     
     deinit {
-        keyedJobs = [:]
+        keyedJobs.values.forEach { unObserveJobStatus(job: $0) }
     }
     
     private func toJSON() -> JSONDictionary {


### PR DESCRIPTION
- Remove the odd `$0.1` reference to a dictionary tuple's value and replace with a more descriptive `$0.value`.
- Rename some non-descriptive variable names.
- Tidy up the coding style around opening block statements to be more consistent.
- Refactor some iterations to be more consistent across the class.