### PR TITLE
KVO and Orientation fixes; remove unnecessary setInitialTransformatio…

### DIFF
--- a/Toolkit/ArcGISToolkit/AR/ArcGISARView.swift
+++ b/Toolkit/ArcGISToolkit/AR/ArcGISARView.swift
@@ -174,7 +174,7 @@ public class ArcGISARView: UIView {
     public override class func keyPathsForValuesAffectingValue(forKey key: String) -> Set<String>
     {
         var set = super.keyPathsForValuesAffectingValue(forKey: key)
-        if key == "translationFactor" {
+        if key == #keyPath(translationFactor) {
             // Get the key paths for super and append our key path to it.
             set.insert(#keyPath(cameraController.translationFactor))
         }

--- a/Toolkit/ArcGISToolkit/AR/ArcGISARView.swift
+++ b/Toolkit/ArcGISToolkit/AR/ArcGISARView.swift
@@ -222,7 +222,7 @@ public class ArcGISARView: UIView {
     
     /// Starts device tracking.
     ///
-    /// - Parameter completion: The completion handler called when start tracking completes.  If it tracking starts successfully, the `error` property will be nil; if tracking fails to start, the error will be non-nil and contain the reason for failure.
+    /// - Parameter completion: The completion handler called when start tracking completes.  If tracking starts successfully, the `error` property will be nil; if tracking fails to start, the error will be non-nil and contain the reason for failure.
     public func startTracking(_ completion: ((_ error: Error?) -> Void)? = nil) {
         // We have a location data source that needs to be started.
         if let locationDataSource = self.locationDataSource {

--- a/Toolkit/ArcGISToolkit/AR/ArcGISARView.swift
+++ b/Toolkit/ArcGISToolkit/AR/ArcGISARView.swift
@@ -402,12 +402,9 @@ extension ArcGISARView: SCNSceneRendererDelegate {
             let imageResolution = camera.imageResolution
             
             // Get the device orientation, but don't allow non-landscape/portrait values.
-            var deviceOrientation = UIDevice.current.orientation
+            let deviceOrientation = UIDevice.current.orientation
             if deviceOrientation.isValidInterfaceOrientation {
                 lastGoodDeviceOrientation = deviceOrientation
-            }
-            else {
-                deviceOrientation = lastGoodDeviceOrientation
             }
             sceneView.setFieldOfViewFromLensIntrinsicsWithXFocalLength(intrinsics[0][0],
                                                                        yFocalLength: intrinsics[1][1],
@@ -415,7 +412,7 @@ extension ArcGISARView: SCNSceneRendererDelegate {
                                                                        yPrincipal: intrinsics[2][1],
                                                                        xImageSize: Float(imageResolution.width),
                                                                        yImageSize: Float(imageResolution.height),
-                                                                       deviceOrientation: deviceOrientation)
+                                                                       deviceOrientation: lastGoodDeviceOrientation)
         }
 
         // Render the Scene with the new transformation.


### PR DESCRIPTION
Update code to support KVO for `originCamera`, `translationFactor`, and `cameraController`.

Limit orientations to just portrait and landscape orientations, eliminating the FaceUp/FaceDown ones.

Remove `setIntialTransformation` method as it did not build in an Obj-C project because it overrode the default setter for the `initialTransformation` property.  Made that property a var.