### PR TITLE
Mhd/ar enhancements

### DIFF
--- a/Examples/ArcGISToolkitExamples/ARExample.swift
+++ b/Examples/ArcGISToolkitExamples/ARExample.swift
@@ -67,6 +67,12 @@ class ARExample: UIViewController {
     /// The toolbar used to display controls for calibration, changing scenes, and status.
     private var toolbar = UIToolbar(frame: .zero)
     
+    /// Button used to display the `CalibrationView`.
+    private let calibrationItem = UIBarButtonItem(title: "Calibration", style: .plain, target: self, action: #selector(displayCalibration(_:)))
+    
+    /// Button used to change the current scene.
+    private let sceneItem = UIBarButtonItem(title: "Change Scene", style: .plain, target: self, action: #selector(changeScene(_:)))
+
     // MARK: Initialization
     
     override func viewDidLoad() {
@@ -181,6 +187,9 @@ class ARExample: UIViewController {
         
         // Hide directions view if we're calibrating.
         userDirectionsView.isHidden = startCalibrating
+        
+        // Disable changing scenes if we're calibrating.
+        sceneItem.isEnabled = !startCalibrating
     }
     
     /// Allow users to change the current scene.
@@ -209,6 +218,12 @@ class ARExample: UIViewController {
                 self.arView.startTracking(useLocationDataSourceOnce: info.useLocationDataSourceOnce, completion: { [weak self] (error) in
                     self?.statusViewController?.errorMessage = error?.localizedDescription
                 })
+                
+                // Disable elevation control if we're using continuous GPS.
+                self.calibrationView?.elevationControlVisibility = info.useLocationDataSourceOnce
+                
+                // Disable calibration if we're in table top
+                self.calibrationItem.isEnabled = !info.tableTop
                 
                 // Reset didPlaceScene variable
                 self.didPlaceScene = false
@@ -244,12 +259,6 @@ class ARExample: UIViewController {
             toolbar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             toolbar.bottomAnchor.constraint(equalTo: arView.sceneView.attributionTopAnchor)
             ])
-        
-        // Create a toolbar button for calibration.
-        let calibrationItem = UIBarButtonItem(title: "Calibration", style: .plain, target: self, action: #selector(displayCalibration(_:)))
-        
-        // Create a toolbar button to change the current scene.
-        let sceneItem = UIBarButtonItem(title: "Change Scene", style: .plain, target: self, action: #selector(changeScene(_:)))
         
         // Create a toolbar button to display the status.
         let statusItem = UIBarButtonItem(title: "Status", style: .plain, target: self, action: #selector(showStatus(_:)))

--- a/Examples/ArcGISToolkitExamples/ARExample.swift
+++ b/Examples/ArcGISToolkitExamples/ARExample.swift
@@ -133,7 +133,9 @@ class ARExample: UIViewController {
                                       (sceneFunction: emptyScene, label: "Empty - Full Scale", tableTop: false, trackingMode: .initial)])
         
         // Use the first sceneInfo to create and set the scene.
-        selectSceneInfo(sceneInfo.first)
+        if let info = sceneInfo.first {
+            selectSceneInfo(info)
+        }
         
         // Debug options for showing world origin and point cloud scene analysis points.
 //        arView.arSCNView.debugOptions = [.showWorldOrigin, .showFeaturePoints]
@@ -194,34 +196,33 @@ class ARExample: UIViewController {
     /// Sets up the required functionality in order to display the scene and AR experience represented by `sceneInfo`.
     ///
     /// - Parameter sceneInfo: The sceneInfo used to set up the scene and AR experience.
-    fileprivate func selectSceneInfo(_ sceneInfo: SceneInfoType?) {
-        guard let info = sceneInfo else { return }
+    fileprivate func selectSceneInfo(_ sceneInfo: SceneInfoType) {
         
         // Set currentSceneInfo to the selected scene info.
-        self.currentSceneInfo = info
+        currentSceneInfo = sceneInfo
         
         // Stop tracking, update the scene with the selected Scene and reset tracking.
-        self.arView.stopTracking()
-        self.arView.sceneView.scene = info.sceneFunction()
-        if info.tableTop {
+        arView.stopTracking()
+        arView.sceneView.scene = sceneInfo.sceneFunction()
+        if sceneInfo.tableTop {
             // Dim the SceneView until the user taps on a surface.
-            self.arView.sceneView.alpha = 0.5
+            arView.sceneView.alpha = 0.5
         }
         
         // Reset AR tracking and then start tracking.
-        self.arView.resetTracking()
-        self.arView.startTracking(info.trackingMode, completion: { [weak self] (error) in
+        arView.resetTracking()
+        arView.startTracking(sceneInfo.trackingMode, completion: { [weak self] (error) in
             self?.statusViewController?.errorMessage = error?.localizedDescription
         })
         
         // Disable elevation control if we're using continuous GPS.
-        self.calibrationView?.elevationControlVisibility = (info.trackingMode != .continuous)
+        calibrationView?.elevationControlVisibility = (sceneInfo.trackingMode != .continuous)
         
         // Disable calibration if we're in table top
-        self.calibrationItem.isEnabled = !info.tableTop
+        calibrationItem.isEnabled = !sceneInfo.tableTop
         
         // Reset didPlaceScene variable
-        self.didPlaceScene = false
+        didPlaceScene = false
     }
     
     /// Allow users to change the current scene.
@@ -696,8 +697,8 @@ extension AGSScene {
 extension ARExample: AGSLocationChangeHandlerDelegate {
     public func locationDataSource(_ locationDataSource: AGSLocationDataSource, locationDidChange location: AGSLocation) {
         // When we get a new location, update the status view controller with the new horizontal and vertical accuracy.
-        statusViewController?.horizontalAccuracyMeasurement = Measurement(value: location.horizontalAccuracy, unit: UnitLength.meters)
-        statusViewController?.verticalAccuracyMeasurement = Measurement(value: location.verticalAccuracy, unit: UnitLength.meters)
+        statusViewController?.horizontalAccuracyMeasurement.value = location.horizontalAccuracy
+        statusViewController?.verticalAccuracyMeasurement.value = location.verticalAccuracy
     }
     
     func locationDataSource(_ locationDataSource: AGSLocationDataSource, statusDidChange status: AGSLocationDataSourceStatus) {

--- a/Examples/ArcGISToolkitExamples/ARExample.swift
+++ b/Examples/ArcGISToolkitExamples/ARExample.swift
@@ -17,7 +17,7 @@ import ArcGISToolkit
 import ArcGIS
 
 class ARExample: UIViewController {
-    
+
     typealias SceneInitFunction = () -> AGSScene
     typealias SceneInfoType = (sceneFunction: SceneInitFunction, label: String, tableTop: Bool, useLocationDataSourceOnce: Bool)
     
@@ -115,7 +115,7 @@ class ARExample: UIViewController {
         addUserDirectionsView()
 
         // Create the CalibrationView.
-        calibrationView = CalibrationView(sceneView: arView.sceneView, cameraController: arView.cameraController)
+        calibrationView = CalibrationView(arView)
         calibrationView?.alpha = 0.0
 
         // Set up the `sceneInfo` array with our scene init functions and labels.

--- a/Examples/ArcGISToolkitExamples/ARExample.swift
+++ b/Examples/ArcGISToolkitExamples/ARExample.swift
@@ -78,6 +78,9 @@ class ARExample: UIViewController {
         // Set ourself as touch delegate so we can get touch events.
         arView.sceneView.touchDelegate = self
         
+        // Set ourself as touch delegate so we can get touch events.
+        arView.locationChangeHandlerDelegate = self
+
         // Disble user interactions on the sceneView.
         arView.sceneView.interactionOptions.isEnabled = false
         
@@ -117,7 +120,7 @@ class ARExample: UIViewController {
 
         // Set up the `sceneInfo` array with our scene init functions and labels.
         sceneInfo.append(contentsOf: [(sceneFunction: streetsScene, label: "Streets - Full Scale", tableTop: false, useLocationDataSourceOnce: false),
-                                      (sceneFunction: imageryScene, label: "Imagery - Full Scale", tableTop: false, useLocationDataSourceOnce: false),
+                                      (sceneFunction: imageryScene, label: "Imagery - Full Scale", tableTop: false, useLocationDataSourceOnce: true),
                                       (sceneFunction: pointCloudScene, label: "Point Cloud - Tabletop", tableTop: true, useLocationDataSourceOnce: true),
                                       (sceneFunction: yosemiteScene, label: "Yosemite - Tabletop", tableTop: true, useLocationDataSourceOnce: true),
                                       (sceneFunction: borderScene, label: "US - Mexico Border - Tabletop", tableTop: true, useLocationDataSourceOnce: true),
@@ -263,7 +266,7 @@ class ARExample: UIViewController {
             statusVC.didMove(toParent: self)
             statusVC.view.translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([
-                statusVC.view.heightAnchor.constraint(equalToConstant: 110),
+                statusVC.view.heightAnchor.constraint(equalToConstant: 176),
                 statusVC.view.widthAnchor.constraint(equalToConstant: 350),
                 statusVC.view.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -8),
                 statusVC.view.bottomAnchor.constraint(equalTo: toolbar.topAnchor, constant: -8)
@@ -661,6 +664,20 @@ extension AGSScene {
         surface.backgroundGrid.isVisible = false
         surface.navigationConstraint = .none
         baseSurface = surface
+    }
+}
+
+// MARK: AGSLocationChangeHandlerDelegate methods
+extension ARExample: AGSLocationChangeHandlerDelegate {
+    public func locationDataSource(_ locationDataSource: AGSLocationDataSource, locationDidChange location: AGSLocation) {
+        // When we get a new location, update the status view controller with the new horizontal and vertical accuracy.
+        statusViewController?.horizontalAccuracy = location.horizontalAccuracy
+        statusViewController?.verticalAccuracy = location.verticalAccuracy
+    }
+    
+    func locationDataSource(_ locationDataSource: AGSLocationDataSource, statusDidChange status: AGSLocationDataSourceStatus) {
+        // Update the data source status.
+        statusViewController?.locationDataSourceStatus = status
     }
 }
 

--- a/Examples/ArcGISToolkitExamples/ARExample.swift
+++ b/Examples/ArcGISToolkitExamples/ARExample.swift
@@ -84,7 +84,7 @@ class ARExample: UIViewController {
         // Set ourself as touch delegate so we can get touch events.
         arView.sceneView.touchDelegate = self
         
-        // Set ourself as touch delegate so we can get touch events.
+        // Set ourself as location change delegate so we can get location data source events.
         arView.locationChangeHandlerDelegate = self
         
         // Disble user interactions on the sceneView.

--- a/Examples/ArcGISToolkitExamples/ARExample.swift
+++ b/Examples/ArcGISToolkitExamples/ARExample.swift
@@ -129,6 +129,9 @@ class ARExample: UIViewController {
         // Use the first sceneInfo to create and set the scene.
         currentSceneInfo = sceneInfo.first
         arView.sceneView.scene = currentSceneInfo?.sceneFunction()
+        
+        // Debug options for showing world origin and point cloud scene analysis points.
+//        arView.arSCNView.debugOptions = [.showWorldOrigin, .showFeaturePoints]
     }
     
     override func viewDidAppear(_ animated: Bool) {

--- a/Examples/ArcGISToolkitExamples/ARExample.swift
+++ b/Examples/ArcGISToolkitExamples/ARExample.swift
@@ -684,8 +684,8 @@ extension AGSScene {
 extension ARExample: AGSLocationChangeHandlerDelegate {
     public func locationDataSource(_ locationDataSource: AGSLocationDataSource, locationDidChange location: AGSLocation) {
         // When we get a new location, update the status view controller with the new horizontal and vertical accuracy.
-        statusViewController?.horizontalAccuracy = location.horizontalAccuracy
-        statusViewController?.verticalAccuracy = location.verticalAccuracy
+        statusViewController?.horizontalAccuracyMeasurement = Measurement(value: location.horizontalAccuracy, unit: UnitLength.meters)
+        statusViewController?.verticalAccuracyMeasurement = Measurement(value: location.verticalAccuracy, unit: UnitLength.meters)
     }
     
     func locationDataSource(_ locationDataSource: AGSLocationDataSource, statusDidChange status: AGSLocationDataSourceStatus) {

--- a/Examples/ArcGISToolkitExamples/ARExample.swift
+++ b/Examples/ArcGISToolkitExamples/ARExample.swift
@@ -17,7 +17,7 @@ import ArcGISToolkit
 import ArcGIS
 
 class ARExample: UIViewController {
-
+    
     typealias SceneInitFunction = () -> AGSScene
     typealias SceneInfoType = (sceneFunction: SceneInitFunction, label: String, tableTop: Bool, useLocationDataSourceOnce: Bool)
     
@@ -54,19 +54,19 @@ class ARExample: UIViewController {
         overlay.sceneProperties = AGSLayerSceneProperties(surfacePlacement: .absolute)
         return overlay
     }()
-        
+    
     /// View for displaying directions to the user.
     private let userDirectionsView = UserDirectionsView(effect: UIBlurEffect(style: .light))
     
     /// The observation for the `SceneView`'s `translationFactor` property.
     private var translationFactorObservation: NSKeyValueObservation?
-
+    
     /// View for displaying calibration controls to the user.
     private var calibrationView: CalibrationView?
-
+    
     /// The toolbar used to display controls for calibration, changing scenes, and status.
     private var toolbar = UIToolbar(frame: .zero)
-
+    
     // MARK: Initialization
     
     override func viewDidLoad() {
@@ -80,7 +80,7 @@ class ARExample: UIViewController {
         
         // Set ourself as touch delegate so we can get touch events.
         arView.locationChangeHandlerDelegate = self
-
+        
         // Disble user interactions on the sceneView.
         arView.sceneView.interactionOptions.isEnabled = false
         
@@ -113,11 +113,11 @@ class ARExample: UIViewController {
         
         // Add the UserDirectionsView.
         addUserDirectionsView()
-
+        
         // Create the CalibrationView.
         calibrationView = CalibrationView(arView)
         calibrationView?.alpha = 0.0
-
+        
         // Set up the `sceneInfo` array with our scene init functions and labels.
         sceneInfo.append(contentsOf: [(sceneFunction: streetsScene, label: "Streets - Full Scale", tableTop: false, useLocationDataSourceOnce: false),
                                       (sceneFunction: imageryScene, label: "Imagery - Full Scale", tableTop: false, useLocationDataSourceOnce: true),
@@ -125,7 +125,7 @@ class ARExample: UIViewController {
                                       (sceneFunction: yosemiteScene, label: "Yosemite - Tabletop", tableTop: true, useLocationDataSourceOnce: true),
                                       (sceneFunction: borderScene, label: "US - Mexico Border - Tabletop", tableTop: true, useLocationDataSourceOnce: true),
                                       (sceneFunction: emptyScene, label: "Empty - Full Scale", tableTop: false, useLocationDataSourceOnce: true)])
-
+        
         // Use the first sceneInfo to create and set the scene.
         currentSceneInfo = sceneInfo.first
         arView.sceneView.scene = currentSceneInfo?.sceneFunction()
@@ -142,7 +142,7 @@ class ARExample: UIViewController {
         super.viewDidDisappear(animated)
         arView.stopTracking()
     }
-
+    
     // MARK: Toolbar button actions
     
     /// Initialize scene location/heading/elevation calibration.
@@ -152,7 +152,7 @@ class ARExample: UIViewController {
         
         // If the sceneView's alpha is 0.0, that means we are not in calibration mode and we need to start calibrating.
         let startCalibrating = (calibrationView?.alpha == 0.0)
-
+        
         // Enable/disable sceneView touch interactions.
         arView.sceneView.interactionOptions.isEnabled = startCalibrating
         userDirectionsView.updateUserDirections(nil)
@@ -179,7 +179,7 @@ class ARExample: UIViewController {
         // Hide directions view if we're calibrating.
         userDirectionsView.isHidden = startCalibrating
     }
-
+    
     /// Allow users to change the current scene.
     ///
     /// - Parameter sender: The bar button item tapped on.
@@ -204,7 +204,7 @@ class ARExample: UIViewController {
                 // Reset AR tracking and then start tracking.
                 self.arView.resetTracking()
                 self.arView.startTracking(useLocationDataSourceOnce: info.useLocationDataSourceOnce, completion: { [weak self] (error) in
-                        self?.statusViewController?.errorMessage = error?.localizedDescription
+                    self?.statusViewController?.errorMessage = error?.localizedDescription
                 })
                 
                 // Reset didPlaceScene variable
@@ -214,11 +214,11 @@ class ARExample: UIViewController {
             action.isEnabled = (info.label != currentSceneInfo?.label)
             alertController.addAction(action)
         }
-
+        
         // Add "cancel" action.
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
         alertController.addAction(cancelAction)
-
+        
         present(alertController, animated: true)
     }
     
@@ -244,20 +244,20 @@ class ARExample: UIViewController {
         
         // Create a toolbar button for calibration.
         let calibrationItem = UIBarButtonItem(title: "Calibration", style: .plain, target: self, action: #selector(displayCalibration(_:)))
-
+        
         // Create a toolbar button to change the current scene.
         let sceneItem = UIBarButtonItem(title: "Change Scene", style: .plain, target: self, action: #selector(changeScene(_:)))
         
         // Create a toolbar button to display the status.
         let statusItem = UIBarButtonItem(title: "Status", style: .plain, target: self, action: #selector(showStatus(_:)))
-
+        
         toolbar.setItems([calibrationItem,
                           UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
                           sceneItem,
                           UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
                           statusItem], animated: false)
     }
-
+    
     /// Set up the status view controller and adds it to the view.
     private func addStatusViewController() {
         if let statusVC = statusViewController {
@@ -366,7 +366,7 @@ extension ARExample: ARSessionDelegate {
 // MARK: AGSGeoViewTouchDelegate
 extension ARExample: AGSGeoViewTouchDelegate {
     public func geoView(_ geoView: AGSGeoView, didTapAtScreenPoint screenPoint: CGPoint, mapPoint: AGSPoint) {
-        if let sceneInfo = currentSceneInfo, sceneInfo.tableTop, !didPlaceScene {
+        if let sceneInfo = currentSceneInfo, sceneInfo.tableTop {
             // We're in table-top mode and haven't placed the scene yet.  Place the scene at the given point by setting the initial transformation.
             if arView.setInitialTransformation(using: screenPoint) {
                 // Show the SceneView now that the user has tapped on the surface.
@@ -382,13 +382,13 @@ extension ARExample: AGSGeoViewTouchDelegate {
         else {
             // We're in full-scale AR mode or have already placed the scene. Get the real world location for screen point from arView.
             guard let point = arView.arScreenToLocation(screenPoint: screenPoint) else { return }
-
+            
             // Create and place a graphic and shadown at the real world location.
             let shadowColor = UIColor.lightGray.withAlphaComponent(0.5)
             let shadow = AGSSimpleMarkerSceneSymbol(style: .sphere, color: shadowColor, height: 0.01, width: 0.25, depth: 0.25, anchorPosition: .center)
             let shadowGraphic = AGSGraphic(geometry: point, symbol: shadow)
             graphicsOverlay.graphics.add(shadowGraphic)
-
+            
             let sphere = AGSSimpleMarkerSceneSymbol(style: .sphere, color: .red, height: 0.25, width: 0.25, depth: 0.25, anchorPosition: .bottom)
             let sphereGraphic = AGSGraphic(geometry: point, symbol: sphere)
             graphicsOverlay.graphics.add(sphereGraphic)
@@ -433,7 +433,8 @@ extension ARExample {
             case .excessiveMotion:
                 message = "Try moving your device more slowly."
             case .initializing:
-                message = "Keep moving your device."
+                // Because ARKit gets reset often when using continuous GPS, only dipslay initializing message if we're using the initial GPS.
+                message = (currentSceneInfo?.useLocationDataSourceOnce ?? false) ? "Keep moving your device." : ""
             case .insufficientFeatures:
                 message = "Try turning on more lights and moving around."
             default:
@@ -633,7 +634,7 @@ extension ARExample {
         arView.locationDataSource = nil
         return scene
     }
-
+    
     /// Creates an empty scene with an elevation source.
     /// Mode:  Full-Scale AR
     ///
@@ -649,7 +650,7 @@ extension ARExample {
         return scene
     }
 }
-    
+
 // MARK: AGSScene extension.
 extension AGSScene {
     /// Adds an elevation source to the given `scene`.

--- a/Examples/ArcGISToolkitExamples/Misc/ARStatusViewController.storyboard
+++ b/Examples/ArcGISToolkitExamples/Misc/ARStatusViewController.storyboard
@@ -145,6 +145,81 @@
                                         </tableViewCellContentView>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="ekj-0f-sbm" detailTextLabel="0eP-3V-71T" style="IBUITableViewCellStyleValue1" id="eg2-Cn-MPS" userLabel="Horizontal Accuracy">
+                                        <rect key="frame" x="0.0" y="110" width="414" height="22"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="eg2-Cn-MPS" id="pHr-qC-QZJ">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="22"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Horizontal Accuracy" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ekj-0f-sbm">
+                                                    <rect key="frame" x="20" y="4" width="114" height="14.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text=" " textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="0eP-3V-71T">
+                                                    <rect key="frame" x="390.5" y="4" width="3.5" height="14.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="12"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="mrE-z3-LMX" detailTextLabel="pGq-AR-lkA" style="IBUITableViewCellStyleValue1" id="eOv-lg-R9o" userLabel="Vertical Accuracy">
+                                        <rect key="frame" x="0.0" y="132" width="414" height="22"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="eOv-lg-R9o" id="tI2-Qt-p93">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="22"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Vertical Accuracy" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="mrE-z3-LMX">
+                                                    <rect key="frame" x="20" y="4" width="99" height="14.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text=" " textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="pGq-AR-lkA">
+                                                    <rect key="frame" x="390.5" y="4" width="3.5" height="14.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="12"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="GxJ-uM-DDB" detailTextLabel="b1W-d9-c8F" style="IBUITableViewCellStyleValue1" id="XDk-OK-RFq" userLabel="Data Source Status">
+                                        <rect key="frame" x="0.0" y="154" width="414" height="22"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="XDk-OK-RFq" id="qsa-Jb-WGq">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="22"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Data Source Status" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="GxJ-uM-DDB">
+                                                    <rect key="frame" x="20" y="4" width="109.5" height="14.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text=" " textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="b1W-d9-c8F">
+                                                    <rect key="frame" x="390.5" y="4" width="3.5" height="14.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="12"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                         </sections>
@@ -156,14 +231,17 @@
                     <connections>
                         <outlet property="errorDescriptionLabel" destination="p4Q-ce-3Qv" id="5yb-vH-ThD"/>
                         <outlet property="frameRateLabel" destination="Zml-dB-qtJ" id="us0-qI-1Ob"/>
+                        <outlet property="horizontalAccuracyLabel" destination="0eP-3V-71T" id="GdF-Hw-aa8"/>
+                        <outlet property="locationDataSourceStatusLabel" destination="b1W-d9-c8F" id="A7Z-Dj-o1L"/>
                         <outlet property="sceneLabel" destination="O0E-15-pU5" id="bvy-jH-2d0"/>
                         <outlet property="trackingStateLabel" destination="0ft-OM-aPL" id="wYT-Bx-mbG"/>
                         <outlet property="translationFactorLabel" destination="Wmr-MU-Oxt" id="jZK-C9-hJr"/>
+                        <outlet property="verticalAccuracyLabel" destination="pGq-AR-lkA" id="MQw-cm-W05"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="K5j-Tq-tyt" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="131.8840579710145" y="155.35714285714286"/>
+            <point key="canvasLocation" x="10" y="471"/>
         </scene>
     </scenes>
 </document>

--- a/Examples/ArcGISToolkitExamples/Misc/ARStatusViewController.swift
+++ b/Examples/ArcGISToolkitExamples/Misc/ARStatusViewController.swift
@@ -76,7 +76,7 @@ class ARStatusViewController: UITableViewController {
         didSet {
             DispatchQueue.main.async{ [weak self] in
                 guard let self = self else { return }
-                self.frameRateLabel?.text = "\(self.frameRate)"
+                self.frameRateLabel?.text = "\(self.frameRate) fps"
             }
         }
     }
@@ -106,27 +106,27 @@ class ARStatusViewController: UITableViewController {
         didSet {
             DispatchQueue.main.async{ [weak self] in
                 guard let self = self else { return }
-                self.translationFactorLabel?.text = String(format: "%.2f", self.translationFactor)
+                self.translationFactorLabel?.text = String(format: "%.1f", self.translationFactor)
             }
         }
     }
 
     /// The horizontal accuracy of the last location.
-    public var horizontalAccuracy: Double = 1.0 {
+    public var horizontalAccuracyMeasurement = Measurement(value: 1, unit: UnitLength.meters) {
         didSet {
             DispatchQueue.main.async{ [weak self] in
                 guard let self = self else { return }
-                self.horizontalAccuracyLabel?.text = String(format: "%.0f", self.horizontalAccuracy)
+                self.horizontalAccuracyLabel?.text = self.measurementFormatter.string(from: self.horizontalAccuracyMeasurement)
             }
         }
     }
 
     /// The vertical accuracy of the last location.
-    public var verticalAccuracy: Double = 1.0 {
+    public var verticalAccuracyMeasurement = Measurement(value: 1, unit: UnitLength.meters) {
         didSet {
             DispatchQueue.main.async{ [weak self] in
                 guard let self = self else { return }
-                self.verticalAccuracyLabel?.text = String(format: "%.0f", self.verticalAccuracy)
+                self.verticalAccuracyLabel?.text = self.measurementFormatter.string(from: self.verticalAccuracyMeasurement)
             }
         }
     }
@@ -140,6 +140,12 @@ class ARStatusViewController: UITableViewController {
             }
         }
     }
+
+    private let measurementFormatter: MeasurementFormatter = {
+        let formatter = MeasurementFormatter()
+        formatter.unitOptions = [.naturalScale, .providedUnit]
+        return formatter
+    }()
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Examples/ArcGISToolkitExamples/Misc/ARStatusViewController.swift
+++ b/Examples/ArcGISToolkitExamples/Misc/ARStatusViewController.swift
@@ -14,6 +14,7 @@
 import UIKit
 import ARKit
 import ArcGIS
+
 extension ARCamera.TrackingState {
     var description: String {
         switch self {
@@ -63,10 +64,9 @@ class ARStatusViewController: UITableViewController {
     /// The `ARKit` camera tracking state.
     public var trackingState: ARCamera.TrackingState = .notAvailable {
         didSet {
-            guard trackingStateLabel != nil else { return }
             DispatchQueue.main.async{ [weak self] in
                 guard let self = self else { return }
-                self.trackingStateLabel.text = self.trackingState.description
+                self.trackingStateLabel?.text = self.trackingState.description
             }
         }
     }
@@ -74,10 +74,9 @@ class ARStatusViewController: UITableViewController {
     /// The calculated frame rate of the `SceneView` and `ARKit` display.
     public var frameRate: Int = 0 {
         didSet {
-            guard frameRateLabel != nil else { return }
             DispatchQueue.main.async{ [weak self] in
                 guard let self = self else { return }
-                self.frameRateLabel.text = "\(self.frameRate)"
+                self.frameRateLabel?.text = "\(self.frameRate)"
             }
         }
     }
@@ -85,10 +84,9 @@ class ARStatusViewController: UITableViewController {
     /// The current error message.
     public var errorMessage: String? {
         didSet {
-            guard errorDescriptionLabel != nil else { return }
             DispatchQueue.main.async{ [weak self] in
                 guard let self = self else { return }
-                self.errorDescriptionLabel.text = self.errorMessage
+                self.errorDescriptionLabel?.text = self.errorMessage
             }
         }
     }
@@ -96,10 +94,9 @@ class ARStatusViewController: UITableViewController {
     /// The label for the currently selected scene.
     public var currentScene: String = "None" {
         didSet {
-            guard sceneLabel != nil else { return }
             DispatchQueue.main.async{ [weak self] in
                 guard let self = self else { return }
-                self.sceneLabel.text = self.currentScene
+                self.sceneLabel?.text = self.currentScene
             }
         }
     }
@@ -107,10 +104,9 @@ class ARStatusViewController: UITableViewController {
     /// The translation factor applied to the current scene.
     public var translationFactor: Double = 1.0 {
         didSet {
-            guard translationFactorLabel != nil else { return }
             DispatchQueue.main.async{ [weak self] in
                 guard let self = self else { return }
-                self.translationFactorLabel.text = String(format: "%.2f", self.translationFactor)
+                self.translationFactorLabel?.text = String(format: "%.2f", self.translationFactor)
             }
         }
     }
@@ -118,10 +114,9 @@ class ARStatusViewController: UITableViewController {
     /// The horizontal accuracy of the last location.
     public var horizontalAccuracy: Double = 1.0 {
         didSet {
-            guard horizontalAccuracyLabel != nil else { return }
             DispatchQueue.main.async{ [weak self] in
                 guard let self = self else { return }
-                self.horizontalAccuracyLabel.text = String(format: "%.0f", self.horizontalAccuracy)
+                self.horizontalAccuracyLabel?.text = String(format: "%.0f", self.horizontalAccuracy)
             }
         }
     }
@@ -129,10 +124,9 @@ class ARStatusViewController: UITableViewController {
     /// The vertical accuracy of the last location.
     public var verticalAccuracy: Double = 1.0 {
         didSet {
-            guard verticalAccuracyLabel != nil else { return }
             DispatchQueue.main.async{ [weak self] in
                 guard let self = self else { return }
-                self.verticalAccuracyLabel.text = String(format: "%.0f", self.verticalAccuracy)
+                self.verticalAccuracyLabel?.text = String(format: "%.0f", self.verticalAccuracy)
             }
         }
     }
@@ -140,10 +134,9 @@ class ARStatusViewController: UITableViewController {
     /// The status of the location data source.
     public var locationDataSourceStatus: AGSLocationDataSourceStatus = .stopped {
         didSet {
-            guard locationDataSourceStatusLabel != nil else { return }
             DispatchQueue.main.async{ [weak self] in
                 guard let self = self else { return }
-                self.locationDataSourceStatusLabel.text = self.locationDataSourceStatus.description
+                self.locationDataSourceStatusLabel?.text = self.locationDataSourceStatus.description
             }
         }
     }

--- a/Examples/ArcGISToolkitExamples/Misc/ARStatusViewController.swift
+++ b/Examples/ArcGISToolkitExamples/Misc/ARStatusViewController.swift
@@ -13,7 +13,7 @@
 
 import UIKit
 import ARKit
-
+import ArcGIS
 extension ARCamera.TrackingState {
     var description: String {
         switch self {
@@ -33,6 +33,21 @@ extension ARCamera.TrackingState {
     }
 }
 
+extension AGSLocationDataSourceStatus {
+    var description: String {
+        switch self {
+        case .stopped:
+            return "Stopped"
+        case .starting:
+            return "Starting"
+        case .started:
+            return "Started"
+        case .failedToStart:
+            return "Failed to start"
+        }
+    }
+}
+
 /// A view controller for display AR-related status information.
 class ARStatusViewController: UITableViewController {
 
@@ -41,7 +56,10 @@ class ARStatusViewController: UITableViewController {
     @IBOutlet var errorDescriptionLabel: UILabel!
     @IBOutlet var sceneLabel: UILabel!
     @IBOutlet var translationFactorLabel: UILabel!
-    
+    @IBOutlet var horizontalAccuracyLabel: UILabel!
+    @IBOutlet var verticalAccuracyLabel: UILabel!
+    @IBOutlet var locationDataSourceStatusLabel: UILabel!
+
     /// The `ARKit` camera tracking state.
     public var trackingState: ARCamera.TrackingState = .notAvailable {
         didSet {
@@ -93,6 +111,39 @@ class ARStatusViewController: UITableViewController {
             DispatchQueue.main.async{ [weak self] in
                 guard let self = self else { return }
                 self.translationFactorLabel.text = String(format: "%.2f", self.translationFactor)
+            }
+        }
+    }
+
+    /// The horizontal accuracy of the last location.
+    public var horizontalAccuracy: Double = 1.0 {
+        didSet {
+            guard horizontalAccuracyLabel != nil else { return }
+            DispatchQueue.main.async{ [weak self] in
+                guard let self = self else { return }
+                self.horizontalAccuracyLabel.text = String(format: "%.0f", self.horizontalAccuracy)
+            }
+        }
+    }
+
+    /// The vertical accuracy of the last location.
+    public var verticalAccuracy: Double = 1.0 {
+        didSet {
+            guard verticalAccuracyLabel != nil else { return }
+            DispatchQueue.main.async{ [weak self] in
+                guard let self = self else { return }
+                self.verticalAccuracyLabel.text = String(format: "%.0f", self.verticalAccuracy)
+            }
+        }
+    }
+
+    /// The status of the location data source.
+    public var locationDataSourceStatus: AGSLocationDataSourceStatus = .stopped {
+        didSet {
+            guard locationDataSourceStatusLabel != nil else { return }
+            DispatchQueue.main.async{ [weak self] in
+                guard let self = self else { return }
+                self.locationDataSourceStatusLabel.text = self.locationDataSourceStatus.description
             }
         }
     }

--- a/Examples/ArcGISToolkitExamples/Misc/CalibrationView.swift
+++ b/Examples/ArcGISToolkitExamples/Misc/CalibrationView.swift
@@ -14,15 +14,13 @@
 
 import UIKit
 import ArcGIS
+import ArcGISToolkit
 
 /// A view displaying controls for adjusting a scene view's location, heading, and elevation. Used to calibrate an AR session.
 class CalibrationView: UIView {
-    
-    // The scene view displaying the scene.
-    private let sceneView: AGSSceneView
 
-    /// The camera controller used to adjust user interactions.
-    private let cameraController: AGSTransformationMatrixCameraController
+    /// The `ArcGISARView` containing the origin camera we will be updating.
+    private var arcgisARView: ArcGISARView!
 
     /// The label displaying calibration directions.
     private let calibrationDirectionsLabel: UILabel = {
@@ -57,17 +55,14 @@ class CalibrationView: UIView {
     // The last heading slider value.
     var lastHeadingValue: Float = 0
 
-    /// Initialized a new calibration view with the given scene view and camera controller.
+    /// Initialized a new calibration view with the `ArcGISARView`.
     ///
     /// - Parameters:
-    ///   - sceneView: The scene view displaying the scene.
-    ///   - cameraController: The camera controller used to adjust user interactions.
-    init(sceneView: AGSSceneView, cameraController: AGSTransformationMatrixCameraController) {
-        self.cameraController = cameraController
-        self.sceneView = sceneView
+    ///   - arcgisARView: The `ArcGISARView` containing the originCamera we're updating.
+    init(_ arcgisARView: ArcGISARView) {
+        self.arcgisARView = arcgisARView
 
         super.init(frame: .zero)
-        
         
         // Create visual effects view to show the label on a blurred background.
         let labelView = UIVisualEffectView(effect: UIBlurEffect(style: .light))
@@ -220,17 +215,17 @@ class CalibrationView: UIView {
     ///
     /// - Parameter deltaHeading: The amount to rotate the camera.
     private func rotate(_ deltaHeading: Double) {
-        let camera = cameraController.originCamera
+        guard let camera = arcgisARView.originCamera else { return }
         let newHeading = camera.heading + deltaHeading
-        cameraController.originCamera = camera.rotate(toHeading: newHeading, pitch: camera.pitch, roll: camera.roll)
+        arcgisARView.originCamera = camera.rotate(toHeading: newHeading, pitch: camera.pitch, roll: camera.roll)
     }
     
     /// Change the cameras altitude by `deltaAltitude`.
     ///
     /// - Parameter deltaAltitude: The amount to elevate the camera.
     private func elevate(_ deltaAltitude: Double) {
-        let camera = cameraController.originCamera
-        cameraController.originCamera = camera.elevate(withDeltaAltitude: deltaAltitude)
+        guard let camera = arcgisARView.originCamera else { return }
+        arcgisARView.originCamera = camera.elevate(withDeltaAltitude: deltaAltitude)
     }
     
     /// Calculates the elevation delta amount based on the elevation slider value.

--- a/Examples/ArcGISToolkitExamples/Misc/CalibrationView.swift
+++ b/Examples/ArcGISToolkitExamples/Misc/CalibrationView.swift
@@ -19,6 +19,14 @@ import ArcGISToolkit
 /// A view displaying controls for adjusting a scene view's location, heading, and elevation. Used to calibrate an AR session.
 class CalibrationView: UIView {
 
+    /// Denotes whether to show the elevation control and label; defaults to `true`.
+    public var elevationControlVisibility: Bool = true {
+        didSet {
+            elevationSlider.isHidden = !elevationControlVisibility
+            elevationLabel.isHidden = !elevationControlVisibility
+        }
+    }
+    
     /// The `ArcGISARView` containing the origin camera we will be updating.
     private var arcgisARView: ArcGISARView!
 
@@ -50,10 +58,13 @@ class CalibrationView: UIView {
     }()
     
     /// The last elevation slider value.
-    var lastElevationValue: Float = 0
+    private var lastElevationValue: Float = 0
     
     // The last heading slider value.
-    var lastHeadingValue: Float = 0
+    private var lastHeadingValue: Float = 0
+    
+    /// The elevation label..
+    private let elevationLabel = UILabel(frame: .zero)
 
     /// Initialized a new calibration view with the `ArcGISARView`.
     ///
@@ -107,7 +118,6 @@ class CalibrationView: UIView {
             ])
 
         // Add the elevation label and slider.
-        let elevationLabel = UILabel(frame: .zero)
         elevationLabel.text = "Elevation"
         elevationLabel.textColor = .yellow
         addSubview(elevationLabel)
@@ -135,6 +145,8 @@ class CalibrationView: UIView {
         elevationSlider.addTarget(self, action: #selector(elevationChanged(_:)), for: .valueChanged)
         elevationSlider.addTarget(self, action: #selector(touchUpElevation(_:)), for: [.touchUpInside, .touchUpOutside])
 
+        elevationSlider.isHidden = !elevationControlVisibility
+        elevationLabel.isHidden = !elevationControlVisibility
     }
     
     required init?(coder aDecoder: NSCoder) {

--- a/Examples/ArcGISToolkitExamples/Misc/CalibrationView.swift
+++ b/Examples/ArcGISToolkitExamples/Misc/CalibrationView.swift
@@ -57,12 +57,6 @@ class CalibrationView: UIView {
         return slider
     }()
     
-    /// The last elevation slider value.
-    private var lastElevationValue: Float = 0
-    
-    // The last heading slider value.
-    private var lastHeadingValue: Float = 0
-    
     /// The elevation label..
     private let elevationLabel = UILabel(frame: .zero)
 

--- a/Examples/ArcGISToolkitExamples/Misc/CalibrationView.swift
+++ b/Examples/ArcGISToolkitExamples/Misc/CalibrationView.swift
@@ -227,7 +227,7 @@ class CalibrationView: UIView {
     ///
     /// - Parameter deltaHeading: The amount to rotate the camera.
     private func rotate(_ deltaHeading: Double) {
-        guard let camera = arcgisARView.originCamera else { return }
+        let camera = arcgisARView.originCamera
         let newHeading = camera.heading + deltaHeading
         arcgisARView.originCamera = camera.rotate(toHeading: newHeading, pitch: camera.pitch, roll: camera.roll)
     }
@@ -236,8 +236,7 @@ class CalibrationView: UIView {
     ///
     /// - Parameter deltaAltitude: The amount to elevate the camera.
     private func elevate(_ deltaAltitude: Double) {
-        guard let camera = arcgisARView.originCamera else { return }
-        arcgisARView.originCamera = camera.elevate(withDeltaAltitude: deltaAltitude)
+        arcgisARView.originCamera = arcgisARView.originCamera.elevate(withDeltaAltitude: deltaAltitude)
     }
     
     /// Calculates the elevation delta amount based on the elevation slider value.

--- a/Toolkit/ArcGISToolkit/AR/ArcGISARView.swift
+++ b/Toolkit/ArcGISToolkit/AR/ArcGISARView.swift
@@ -38,9 +38,6 @@ public class ArcGISARView: UIView {
             locationDataSource?.locationChangeHandlerDelegate = self
         }
     }
-    
-    /// The `AGSTransformationMatrixCameraController` used to control the Scene.
-    @objc public let cameraController = AGSTransformationMatrixCameraController()
 
     /// The viewpoint camera used to set the initial view of the sceneView instead of the device's GPS location via the location data source.  You can use Key-Value Observing to track changes to the origin camera.
     @objc dynamic public var originCamera: AGSCamera? {
@@ -86,7 +83,10 @@ public class ArcGISARView: UIView {
     weak public var locationChangeHandlerDelegate: AGSLocationChangeHandlerDelegate?
 
     // MARK: Private properties
-    
+        
+    /// The `AGSTransformationMatrixCameraController` used to control the Scene.
+    @objc private let cameraController = AGSTransformationMatrixCameraController()
+
     /// Used when calculating framerate.
     private var lastUpdateTime: TimeInterval = 0
     

--- a/Toolkit/ArcGISToolkit/AR/ArcGISARView.swift
+++ b/Toolkit/ArcGISToolkit/AR/ArcGISARView.swift
@@ -310,7 +310,7 @@ public class ArcGISARView: UIView {
     /// - Returns: An `AGSTransformationMatrix` representing the real-world point corresponding to `screenPoint`.
     fileprivate func internalHitTest(screenPoint: CGPoint) -> AGSTransformationMatrix? {
         // Use the `hitTest` method on ARSCNView to get the location of `screenPoint`.
-        let results = arSCNView.hitTest(screenPoint, types: [.existingPlane, .estimatedHorizontalPlane])
+        let results = arSCNView.hitTest(screenPoint, types: .existingPlaneUsingExtent)
         
         // Get the worldTransform from the first result; if there's no worldTransform, return nil.
         guard let worldTransform = results.first?.worldTransform else { return nil }


### PR DESCRIPTION
Enhancements and bug fixes, including, but not limited to:

- When continuous GPS is enabled it would be a nice if we hid the elevation calibration slider
- Calibration should be disabled in Table top
- Suppress user directions view message: "Keep moving your device" when using continuous GPS locations. This is because with every location update, ARKit is reset, so it's perpetually in a state of initialization.
- Disable changing scenes if we're calibrating.
- Pass LocationDataSourceDelegate methods through to client
- add horizontalAccuracy, verticalAccuracy and LDS status to StatusVC