### PR TITLE
Suggested edits

### DIFF
--- a/Documentation/AR/README.md
+++ b/Documentation/AR/README.md
@@ -3,17 +3,17 @@
 Augmented reality experiences are designed to "augment" the physical world with virtual content that respects real world scale, position, and orientation of a device. In the case of Runtime, a SceneView contains 3D geographic data as virtual content on top of a camera feed which represents the real, physical world.
 
 The Augmented Reality (AR) toolkit component allows quick and easy integration of AR into your application for a wide variety of scenarios.  The toolkit recognizes the following common patterns for AR: 
-* Flyover – Flyover AR is a kind of AR scenario that allows you to explore a scene using your device as a window into the virtual world. A typical flyover AR scenario will start with the scene’s virtual camera positioned over an area of interest. You can walk around and reorient the device to focus on specific content in the scene. 
-* Tabletop – A kind of AR scenario where scene content is anchored to a physical surface, as if it were a 3D-printed model. 
-* Real-scale – A kind of AR scenario where scene content is rendered exactly where it would be in the physical world. A camera feed is shown and GIS content is rendered on top of that feed. This is used in scenarios ranging from viewing hidden infrastructure to displaying waypoints for navigation. 
+* **Flyover**: Flyover AR allows you to explore a scene using your device as a window into the virtual world. A typical flyover AR scenario will start with the scene’s virtual camera positioned over an area of interest. You can walk around and reorient the device to focus on specific content in the scene. 
+* **Tabletop**: Scene content is anchored to a physical surface, as if it were a 3D-printed model. 
+* **Real-scale**: Scene content is rendered exactly where it would be in the physical world. A camera feed is shown and GIS content is rendered on top of that feed. This is used in scenarios ranging from viewing hidden infrastructure to displaying waypoints for navigation.
 
 The AR toolkit component is comprised of one class: `ArcGISARView`.  This is a subclass of `UIView` that contains the functionality needed to display an AR experience in your application.  It uses `ARKit`, Apple's augmented reality framework to display the live camera feed and handle real world tracking and synchronization with the Runtime SDK's `AGSSceneView`.  The `ArcGISARView` is responsible for starting and managing an `ARKit` session.  It uses a user-provided `AGSLocationDataSource` for getting an initial GPS location and when continuous GPS tracking is required.
 
 ### Features of the AR component
 
-- Allows display of live camera feed
+- Allows display of the live camera feed
 - Manages `ARKit` `ARSession` lifecycle
-- Ability to track users location and device orientation through a combination of `ARKit` and the device GPS
+- Tracks user location and device orientation through a combination of `ARKit` and the device GPS
 - Provides access to an `AGSSceneView` to display your GIS 3D data over the live camera feed
 - `ARScreenToLocation` method to convert a screen point to a real-world coordinate
 - Easy access to all `ARKit` and `AGSLocationDataSource` delegate methods
@@ -51,7 +51,3 @@ You must also add the following entries to your application's Info.plist file to
 * Privacy – Location When In Use Usage Description 
 
 To see it in action, try out the [Examples](../../Examples) and refer to [ARExample.swift](../../Examples/ArcGISToolkitExamples/ARExample.swift) in the project.
-
-
-
-


### PR DESCRIPTION
Just suggested a couple of edits for consistency, and I think the "**Bold**:" works nicely for the bullet list.

A couple of other thoughts:

1. You mention "It uses a user-provided AGSLocationDataSource for getting an initial GPS location and when continuous GPS tracking is required" but should we mention that this is the default? It sounds as if the user will need to create one of these and provide it (I assume that's not usually the case).
2. This seems like it could be restructured to be a little clearer: "You must also add the following entries to your application's Info.plist file to support use of the camera (for the live video feed) and, when using the AGSCLLocationDataSource, the GPS (for determining your device's location)".
3. For the `info.plist` keys, should we also list the actual literals (like `NSLocationWhenInUseUsageDescription`) and link to the [Apple doc](https://developer.apple.com/documentation/bundleresources/information_property_list/nslocationwheninuseusagedescription)?