### PR TITLE
Reset the clipping distance for the Yosemite scene so it doesn't use …

### DIFF
--- a/Examples/ArcGISToolkitExamples/ARExample.swift
+++ b/Examples/ArcGISToolkitExamples/ARExample.swift
@@ -604,6 +604,9 @@ extension ARExample {
                     let camera = AGSCamera(latitude: center.y, longitude: center.x, altitude: elevation, heading: 0, pitch: 90, roll: 0)
                     self?.arView.originCamera = camera
                     self?.arView.translationFactor = 18000
+                    
+                    // Reset the clipping distance so we view the full scene.
+                    self?.arView.clippingDistance = 0
                 }
             }
         }


### PR DESCRIPTION
The Yosemite scene was using a clipping distance from a previous tabletop scene; set the clippingDistance to 0 for Yosemite, as we don't want a clippingDistance for that scene.