### PR TITLE
use new background task framework for job manager

### DIFF
--- a/Examples/ArcGISToolkitExamples.xcodeproj/project.pbxproj
+++ b/Examples/ArcGISToolkitExamples.xcodeproj/project.pbxproj
@@ -230,6 +230,7 @@
 				TargetAttributes = {
 					8839043A1DF6022A001F3188 = {
 						CreatedOnToolsVersion = 8.0;
+						DevelopmentTeam = P8HGHS7JQ8;
 						LastSwiftMigration = 1110;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
@@ -508,7 +509,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = P8HGHS7JQ8;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(USER_LIBRARY_DIR)/SDKs/ArcGIS/iOS/Frameworks/Dynamic",
@@ -528,7 +529,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = P8HGHS7JQ8;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(USER_LIBRARY_DIR)/SDKs/ArcGIS/iOS/Frameworks/Dynamic",

--- a/Examples/ArcGISToolkitExamples.xcodeproj/project.pbxproj
+++ b/Examples/ArcGISToolkitExamples.xcodeproj/project.pbxproj
@@ -230,7 +230,6 @@
 				TargetAttributes = {
 					8839043A1DF6022A001F3188 = {
 						CreatedOnToolsVersion = 8.0;
-						DevelopmentTeam = P8HGHS7JQ8;
 						LastSwiftMigration = 1110;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
@@ -509,7 +508,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				DEVELOPMENT_TEAM = P8HGHS7JQ8;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(USER_LIBRARY_DIR)/SDKs/ArcGIS/iOS/Frameworks/Dynamic",
@@ -529,7 +528,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				DEVELOPMENT_TEAM = P8HGHS7JQ8;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(USER_LIBRARY_DIR)/SDKs/ArcGIS/iOS/Frameworks/Dynamic",

--- a/Examples/ArcGISToolkitExamples/AppDelegate.swift
+++ b/Examples/ArcGISToolkitExamples/AppDelegate.swift
@@ -23,7 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         if #available(iOS 13.0, *) {
             let result = JobManager.shared.registerForBackgroundUpdates()
-            print("background registration result: \(result)")
+            print("-- background registration result: \(result)")
         }
         
         return true

--- a/Examples/ArcGISToolkitExamples/AppDelegate.swift
+++ b/Examples/ArcGISToolkitExamples/AppDelegate.swift
@@ -20,6 +20,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         // Override point for customization after application launch.
+        
+        if #available(iOS 13.0, *) {
+            let result = JobManager.shared.registerForBackgroundUpdates()
+            print("background registration result: \(result)")
+        }
+        
         return true
     }
 
@@ -48,6 +54,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // Here is where we forward background fetch to the JobManager
     // so that jobs can be updated in the background
     func application(_ application: UIApplication, performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+        // We only do it this way for pre-iOS 13. Otherwise we use BGTask above.
+        // This method doesn't get called for iOS 13 or later because we have an entry
+        // in the plist for BGTaskSchedulerPermittedIdentifiers.
         JobManager.shared.application(application: application, performFetchWithCompletionHandler: completionHandler)
     }
 }

--- a/Examples/ArcGISToolkitExamples/AppDelegate.swift
+++ b/Examples/ArcGISToolkitExamples/AppDelegate.swift
@@ -22,8 +22,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         
         if #available(iOS 13.0, *) {
-            let result = JobManager.shared.registerForBackgroundUpdates()
-            print("-- background registration result: \(result)")
+            JobManager.shared.registerForBackgroundUpdates()
         }
         
         return true

--- a/Examples/ArcGISToolkitExamples/Info.plist
+++ b/Examples/ArcGISToolkitExamples/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.esri.arcgis.toolkit.jobmanager.refresh</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/Examples/ArcGISToolkitExamples/JobManagerExample.swift
+++ b/Examples/ArcGISToolkitExamples/JobManagerExample.swift
@@ -129,19 +129,6 @@ class JobManagerExample: TableViewController {
         // now anchor toolbar below new safe area
         toolbar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor).isActive = true
         
-        // button to kick off a new job
-        let kickOffJobItem = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(kickOffJob))
-        
-        // button to resume all paused jobs
-        // use this to resume the paused jobs you have after restarting your app
-        let resumeAllPausedJobsItem = UIBarButtonItem(barButtonSystemItem: .play, target: self, action: #selector(resumeAllPausedJobs))
-        
-        // button to clear the finished jobs
-        let clearFinishedJobsItem = UIBarButtonItem(barButtonSystemItem: .trash, target: self, action: #selector(clearFinishedJobs))
-        
-        let flex = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-        toolbar.items = [kickOffJobItem, flex, resumeAllPausedJobsItem, flex, clearFinishedJobsItem]
-        
         // request authorization for user notifications, this way we can notify user in bg when job complete
         let center = UNUserNotificationCenter.current()
         center.requestAuthorization(options: [.alert, .badge, .sound]) { (granted, _) in
@@ -152,6 +139,25 @@ class JobManagerExample: TableViewController {
         
         // job cell registration
         tableView.register(JobTableViewCell.self, forCellReuseIdentifier: "JobCell")
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        if let toolbar = toolbar, toolbar.items == nil {
+            // button to kick off a new job
+            let kickOffJobItem = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(kickOffJob))
+            
+            // button to resume all paused jobs
+            // use this to resume the paused jobs you have after restarting your app
+            let resumeAllPausedJobsItem = UIBarButtonItem(barButtonSystemItem: .play, target: self, action: #selector(resumeAllPausedJobs))
+            
+            // button to clear the finished jobs
+            let clearFinishedJobsItem = UIBarButtonItem(barButtonSystemItem: .trash, target: self, action: #selector(clearFinishedJobs))
+            
+            let flexibleSpace1 = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+            let flexibleSpace2 = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+            toolbar.items = [kickOffJobItem, flexibleSpace1, resumeAllPausedJobsItem, flexibleSpace2, clearFinishedJobsItem]
+        }
     }
     
     @objc

--- a/Examples/ArcGISToolkitExamples/JobManagerExample.swift
+++ b/Examples/ArcGISToolkitExamples/JobManagerExample.swift
@@ -151,6 +151,18 @@ class JobManagerExample: TableViewController {
         )
     }
     
+    deinit {
+        // When we are deinited we pause all running jobs.
+        // In a normal app you would not need to do this, but this view controller
+        // is acting as an app example. Thus when it goes out of scope, we pause
+        // the jobs so that when the view controller is re-shown we can resume and rewire
+        // the handlers up to them. Otherwise we would have no way to hook into the status
+        // of any currently running jobs. A normal app would not likely need this as it would
+        // have an object globally wiring up status and completion handlers to jobs.
+        // But since this sample view controller can be pushed/pop, we need this.
+        JobManager.shared.pauseAllJobs()
+    }
+    
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         if let toolbar = toolbar, toolbar.items == nil {

--- a/Examples/ArcGISToolkitExamples/JobManagerExample.swift
+++ b/Examples/ArcGISToolkitExamples/JobManagerExample.swift
@@ -139,8 +139,10 @@ class JobManagerExample: TableViewController {
         
         // job cell registration
         tableView.register(JobTableViewCell.self, forCellReuseIdentifier: "JobCell")
-        
-        // resume any paused jobs
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        // resume any paused jobs when this view controller is shown
         JobManager.shared.resumeAllPausedJobs(
             statusHandler: { [weak self] in
                 self?.jobStatusHandler(status: $0)
@@ -149,18 +151,22 @@ class JobManagerExample: TableViewController {
                 self?.jobCompletionHandler(result: $0, error: $1)
             }
         )
+        
+        super.viewDidAppear(animated)
     }
     
-    deinit {
-        // When we are deinited we pause all running jobs.
+    override func viewWillDisappear(_ animated: Bool) {
+        // When the view controller is popped, we pause all running jobs.
         // In a normal app you would not need to do this, but this view controller
-        // is acting as an app example. Thus when it goes out of scope, we pause
+        // is acting as an app example. Thus when it is not being shown, we pause
         // the jobs so that when the view controller is re-shown we can resume and rewire
         // the handlers up to them. Otherwise we would have no way to hook into the status
         // of any currently running jobs. A normal app would not likely need this as it would
         // have an object globally wiring up status and completion handlers to jobs.
         // But since this sample view controller can be pushed/pop, we need this.
         JobManager.shared.pauseAllJobs()
+        
+        super.viewWillDisappear(animated)
     }
     
     override func viewDidLayoutSubviews() {

--- a/Examples/ArcGISToolkitExamples/JobManagerExample.swift
+++ b/Examples/ArcGISToolkitExamples/JobManagerExample.swift
@@ -139,6 +139,9 @@ class JobManagerExample: TableViewController {
         
         // job cell registration
         tableView.register(JobTableViewCell.self, forCellReuseIdentifier: "JobCell")
+        
+        // resume any paused jobs
+        JobManager.shared.resumeAllPausedJobs(statusHandler: self.jobStatusHandler, completion: self.jobCompletionHandler)
     }
     
     override func viewDidLayoutSubviews() {
@@ -147,22 +150,12 @@ class JobManagerExample: TableViewController {
             // button to kick off a new job
             let kickOffJobItem = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(kickOffJob))
             
-            // button to resume all paused jobs
-            // use this to resume the paused jobs you have after restarting your app
-            let resumeAllPausedJobsItem = UIBarButtonItem(barButtonSystemItem: .play, target: self, action: #selector(resumeAllPausedJobs))
-            
             // button to clear the finished jobs
             let clearFinishedJobsItem = UIBarButtonItem(barButtonSystemItem: .trash, target: self, action: #selector(clearFinishedJobs))
             
-            let flexibleSpace1 = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-            let flexibleSpace2 = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-            toolbar.items = [kickOffJobItem, flexibleSpace1, resumeAllPausedJobsItem, flexibleSpace2, clearFinishedJobsItem]
+            let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+            toolbar.items = [kickOffJobItem, flexibleSpace, clearFinishedJobsItem]
         }
-    }
-    
-    @objc
-    func resumeAllPausedJobs() {
-        JobManager.shared.resumeAllPausedJobs(statusHandler: self.jobStatusHandler, completion: self.jobCompletionHandler)
     }
     
     @objc

--- a/Toolkit/ArcGISToolkit/JobManager.swift
+++ b/Toolkit/ArcGISToolkit/JobManager.swift
@@ -262,7 +262,7 @@ public class JobManager: NSObject {
     @available(iOS 13.0, *)
     private func scheduleNextBackgroundRefresh() {
         let request = BGAppRefreshTaskRequest(identifier: bgTaskIdentifier)
-        request.earliestBeginDate = Date(timeIntervalSinceNow: 60)
+        request.earliestBeginDate = Date(timeIntervalSinceNow: 30)
         
         do {
             try BGTaskScheduler.shared.submit(request)

--- a/Toolkit/ArcGISToolkit/JobManager.swift
+++ b/Toolkit/ArcGISToolkit/JobManager.swift
@@ -222,7 +222,8 @@ public class JobManager: NSObject {
     
     /// Registers a task for updating job status in the background.
     /// You must add an entry in the app plist for com.esri.arcgis.toolkit.jobmanager.refresh under BGTaskSchedulerPermittedIdentifiers.
-    /// This must be called before the end of the app launch sequence. This must be tested on device, does not work on the simulator.
+    /// This must be called before the end of the app launch sequence.
+    /// This must be tested on device, does not work on the simulator. For debugging this, see documentation here: https://developer.apple.com/documentation/backgroundtasks/starting_and_terminating_tasks_during_development?language=objc
     @available(iOS 13.0, *)
     @discardableResult
     public func registerForBackgroundUpdates() -> Bool {

--- a/Toolkit/ArcGISToolkit/JobManager.swift
+++ b/Toolkit/ArcGISToolkit/JobManager.swift
@@ -287,6 +287,13 @@ public class JobManager: NSObject {
         }
     }
     
+    /// Pauses any currently running job.
+    public func pauseAllJobs() {
+        keyedJobs.lazy.filter { $0.value.status == AGSJobStatus.started }.forEach {
+            $0.value.progress.pause()
+        }
+    }
+    
     /// Saves all managed `AGSJob`s to User Defaults.
     ///
     /// This happens automatically when the `AGSJob`s are registered/unregistered.

--- a/Toolkit/ArcGISToolkit/JobManager.swift
+++ b/Toolkit/ArcGISToolkit/JobManager.swift
@@ -289,8 +289,9 @@ public class JobManager: NSObject {
     
     /// Pauses any currently running job.
     public func pauseAllJobs() {
-        keyedJobs.lazy.filter { $0.value.status == AGSJobStatus.started }.forEach {
-            $0.value.progress.pause()
+        keyedJobs.values.forEach {
+            guard $0.status == .started else { return }
+            $0.progress.pause()
         }
     }
     

--- a/Toolkit/ArcGISToolkit/JobManager.swift
+++ b/Toolkit/ArcGISToolkit/JobManager.swift
@@ -260,7 +260,6 @@ public class JobManager: NSObject {
     @available(iOS 13.0, *)
     private func scheduleNextBackgroundRefresh() {
         let request = BGAppRefreshTaskRequest(identifier: bgTaskIdentifier)
-        // Fetch no earlier than 15 seconds from now
         request.earliestBeginDate = Date(timeIntervalSinceNow: 60)
         
         do {

--- a/Toolkit/ArcGISToolkit/JobManager.swift
+++ b/Toolkit/ArcGISToolkit/JobManager.swift
@@ -244,14 +244,11 @@ public class JobManager: NSObject {
     
     @available(iOS 13.0, *)
     private func handleBackgroundRefresh(task: BGAppRefreshTask) {
-        print("-- handleBackgroundRefresh")
-        
-        // Schedule next
+        // Schedule next refresh
         scheduleNextBackgroundRefresh()
         
         // check job status
         let operation = JobManager.shared.checkStatusForAllJobs { success in
-            print("-- status check done: \(success)")
             task.setTaskCompleted(success: success)
         }
         
@@ -262,7 +259,6 @@ public class JobManager: NSObject {
     
     @available(iOS 13.0, *)
     private func scheduleNextBackgroundRefresh() {
-        print("-- scheduleNextBackgroundRefresh")
         let request = BGAppRefreshTaskRequest(identifier: bgTaskIdentifier)
         // Fetch no earlier than 15 seconds from now
         request.earliestBeginDate = Date(timeIntervalSinceNow: 60)
@@ -270,7 +266,7 @@ public class JobManager: NSObject {
         do {
             try BGTaskScheduler.shared.submit(request)
         } catch {
-            print("-- Could not schedule app refresh: \(error)")
+            print("Could not schedule app refresh: \(error)")
         }
     }
     

--- a/Toolkit/ArcGISToolkit/JobManager.swift
+++ b/Toolkit/ArcGISToolkit/JobManager.swift
@@ -224,12 +224,14 @@ public class JobManager: NSObject {
     /// You must add an entry in the app plist for com.esri.arcgis.toolkit.jobmanager.refresh under BGTaskSchedulerPermittedIdentifiers.
     /// This must be called before the end of the app launch sequence.
     /// This must be tested on device, does not work on the simulator. For debugging this, see documentation here: https://developer.apple.com/documentation/backgroundtasks/starting_and_terminating_tasks_during_development?language=objc
+    /// Returns whether or not the registration was successful. If the registration was not successful, please check your application's plist for the appropriately entry
+    /// as mentioned above.
     @available(iOS 13.0, *)
     @discardableResult
     public func registerForBackgroundUpdates() -> Bool {
         // register the bg task
-        let result = BGTaskScheduler.shared.register(forTaskWithIdentifier: bgTaskIdentifier, using: nil) { task in
-            self.handleBackgroundRefresh(task: task as! BGAppRefreshTask)
+        let result = BGTaskScheduler.shared.register(forTaskWithIdentifier: bgTaskIdentifier, using: nil) { [weak self] task in
+            self?.handleBackgroundRefresh(task: task as! BGAppRefreshTask)
         }
         
         // schedule a notification when application enters background


### PR DESCRIPTION
As Mark pointed out, the old way of doing background fetch has been deprecated. This adds support for the new way for iOS 13 devices.

BTW - for iOS 12 devices the old way still works - you just need to use the Xcode menu: `Debug -> Simulate Background Fetch`.

For iOS 13 devices, there is no way to test this on the simulator. You have to use a device and the documentation for testing it is [here](https://developer.apple.com/documentation/backgroundtasks/starting_and_terminating_tasks_during_development?language=objc)

This builds on the PR from @philium [here](https://github.com/Esri/arcgis-runtime-toolkit-ios/pull/91). So that should be merged first.

