### PR TITLE
job manager: use background task to keep app alive

### DIFF
--- a/Examples/ArcGISToolkitExamples.xcodeproj/project.pbxproj
+++ b/Examples/ArcGISToolkitExamples.xcodeproj/project.pbxproj
@@ -230,6 +230,7 @@
 				TargetAttributes = {
 					8839043A1DF6022A001F3188 = {
 						CreatedOnToolsVersion = 8.0;
+						DevelopmentTeam = P8HGHS7JQ8;
 						LastSwiftMigration = 1110;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
@@ -508,7 +509,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = P8HGHS7JQ8;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(USER_LIBRARY_DIR)/SDKs/ArcGIS/iOS/Frameworks/Dynamic",
@@ -528,7 +529,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = P8HGHS7JQ8;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(USER_LIBRARY_DIR)/SDKs/ArcGIS/iOS/Frameworks/Dynamic",

--- a/Examples/ArcGISToolkitExamples.xcodeproj/project.pbxproj
+++ b/Examples/ArcGISToolkitExamples.xcodeproj/project.pbxproj
@@ -230,7 +230,6 @@
 				TargetAttributes = {
 					8839043A1DF6022A001F3188 = {
 						CreatedOnToolsVersion = 8.0;
-						DevelopmentTeam = P8HGHS7JQ8;
 						LastSwiftMigration = 1110;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
@@ -509,7 +508,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				DEVELOPMENT_TEAM = P8HGHS7JQ8;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(USER_LIBRARY_DIR)/SDKs/ArcGIS/iOS/Frameworks/Dynamic",
@@ -529,7 +528,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				DEVELOPMENT_TEAM = P8HGHS7JQ8;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(USER_LIBRARY_DIR)/SDKs/ArcGIS/iOS/Frameworks/Dynamic",

--- a/Examples/ArcGISToolkitExamples/AppDelegate.swift
+++ b/Examples/ArcGISToolkitExamples/AppDelegate.swift
@@ -20,11 +20,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         // Override point for customization after application launch.
-        
-        if #available(iOS 13.0, *) {
-            JobManager.shared.registerForBackgroundUpdates()
-        }
-        
         return true
     }
 

--- a/Examples/ArcGISToolkitExamples/AppDelegate.swift
+++ b/Examples/ArcGISToolkitExamples/AppDelegate.swift
@@ -44,17 +44,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
-    
-    // Here is where we forward background fetch to the JobManager
-    // so that jobs can be updated in the background
-    func application(_ application: UIApplication, performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
-        // We only do it this way for pre-iOS 13. Otherwise we use BGTask above.
-        // This method doesn't get called for iOS 13 or later because we have an entry
-        // in the plist for BGTaskSchedulerPermittedIdentifiers.
-        if #available(iOS 13.0, *) {
-            // Nothing to do here.
-        } else {
-            JobManager.shared.application(application: application, performFetchWithCompletionHandler: completionHandler)
-        }
-    }
 }

--- a/Examples/ArcGISToolkitExamples/Info.plist
+++ b/Examples/ArcGISToolkitExamples/Info.plist
@@ -32,9 +32,7 @@
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>For collecting attachments in popups</string>
 	<key>UIBackgroundModes</key>
-	<array>
-		<string>fetch</string>
-	</array>
+	<array/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/Examples/ArcGISToolkitExamples/Info.plist
+++ b/Examples/ArcGISToolkitExamples/Info.plist
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BGTaskSchedulerPermittedIdentifiers</key>
-	<array>
-		<string>com.esri.arcgis.toolkit.jobmanager.refresh</string>
-	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/Examples/ArcGISToolkitExamples/JobManagerExample.swift
+++ b/Examples/ArcGISToolkitExamples/JobManagerExample.swift
@@ -309,8 +309,8 @@ class JobManagerExample: TableViewController {
                     self?.jobStatusHandler(status: $0)
                 },
                 completion: { [weak self] in
-                    self?.endBackgroundTask(backgroundTaskIdentifier)
                     self?.jobCompletionHandler(result: $0, error: $1)
+                    self?.endBackgroundTask(backgroundTaskIdentifier)
                 }
             )
             
@@ -360,8 +360,8 @@ class JobManagerExample: TableViewController {
                         self?.jobStatusHandler(status: $0)
                     },
                     completion: { [weak self] in
-                        self?.endBackgroundTask(backgroundTaskIdentifier)
                         self?.jobCompletionHandler(result: $0, error: $1)
+                        self?.endBackgroundTask(backgroundTaskIdentifier)
                     }
                 )
                 

--- a/Examples/ArcGISToolkitExamples/JobManagerExample.swift
+++ b/Examples/ArcGISToolkitExamples/JobManagerExample.swift
@@ -175,6 +175,12 @@ class JobManagerExample: TableViewController {
         super.viewWillDisappear(animated)
     }
     
+    deinit {
+        // clear out background tasks that we started for the jobs
+        backgroundTaskIdentifiers.forEach { UIApplication.shared.endBackgroundTask($0) }
+        backgroundTaskIdentifiers.removeAll()
+    }
+    
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         if let toolbar = toolbar, toolbar.items == nil {
@@ -253,7 +259,7 @@ class JobManagerExample: TableViewController {
             // make sure we are still around...
             guard let self = self, let strongTask = task else {
                 // don't need to end the background task here as that
-                // would have been done in dealloc
+                // would have been done in deinit
                 return
             }
             
@@ -341,7 +347,7 @@ class JobManagerExample: TableViewController {
             // make sure we are still around...
             guard let self = self else {
                 // don't need to end the background task here as that
-                // would have been done in dealloc
+                // would have been done in deinit
                 return
             }
             

--- a/Examples/ArcGISToolkitExamples/JobManagerExample.swift
+++ b/Examples/ArcGISToolkitExamples/JobManagerExample.swift
@@ -22,17 +22,10 @@ import UserNotifications
 // restart the application, and find out what jobs were running and have the ability to
 // resume them.
 //
-// The other aspect of this sample is that if you just background the app then it will
-// provide a helper method that helps with background fetch.
-//
-// See the AppDelegate.swift for implementation of the function:
-// `func application(_ application: UIApplication, performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void)`
-// We forward that call to the shared JobManager so that it can perform the background fetch.
-//
 
 class JobTableViewCell: UITableViewCell {
     var job: AGSJob?
-    var statusObservation: NSKeyValueObservation?
+    var observation: NSKeyValueObservation?
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
@@ -44,15 +37,15 @@ class JobTableViewCell: UITableViewCell {
     
     func configureWithJob(job: AGSJob?) {
         // invalidate previous observation
-        statusObservation?.invalidate()
-        statusObservation = nil
+        observation?.invalidate()
+        observation = nil
         
         self.job = job
         
         self.updateUI()
         
-        // observe job status
-        statusObservation = self.job?.observe(\.status, options: .new) { [weak self] (_, _) in
+        // observe job
+        observation = self.job?.progress.observe(\.fractionCompleted) { [weak self] (_, _) in
             DispatchQueue.main.async {
                 self?.updateUI()
             }
@@ -178,7 +171,6 @@ class JobManagerExample: TableViewController {
     deinit {
         // clear out background tasks that we started for the jobs
         backgroundTaskIdentifiers.forEach { UIApplication.shared.endBackgroundTask($0) }
-        backgroundTaskIdentifiers.removeAll()
     }
     
     func startBackgroundTask() -> UIBackgroundTaskIdentifier {

--- a/Examples/ArcGISToolkitExamples/JobManagerExample.swift
+++ b/Examples/ArcGISToolkitExamples/JobManagerExample.swift
@@ -181,6 +181,20 @@ class JobManagerExample: TableViewController {
         backgroundTaskIdentifiers.removeAll()
     }
     
+    func startBackgroundTask() -> UIBackgroundTaskIdentifier {
+        var backgroundTaskIdentifier: UIBackgroundTaskIdentifier = .invalid
+        backgroundTaskIdentifier = UIApplication.shared.beginBackgroundTask {
+            UIApplication.shared.endBackgroundTask(backgroundTaskIdentifier)
+        }
+        backgroundTaskIdentifiers.insert(backgroundTaskIdentifier)
+        return backgroundTaskIdentifier
+    }
+    
+    func endBackgroundTask(_ identifier: UIBackgroundTaskIdentifier) {
+        UIApplication.shared.endBackgroundTask(identifier)
+        backgroundTaskIdentifiers.remove(identifier)
+    }
+    
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         if let toolbar = toolbar, toolbar.items == nil {
@@ -318,20 +332,6 @@ class JobManagerExample: TableViewController {
             // refresh the tableview
             self.tableView.reloadData()
         }
-    }
-    
-    func startBackgroundTask() -> UIBackgroundTaskIdentifier {
-        var backgroundTaskIdentifier: UIBackgroundTaskIdentifier = .invalid
-        backgroundTaskIdentifier = UIApplication.shared.beginBackgroundTask {
-            UIApplication.shared.endBackgroundTask(backgroundTaskIdentifier)
-        }
-        backgroundTaskIdentifiers.insert(backgroundTaskIdentifier)
-        return backgroundTaskIdentifier
-    }
-    
-    func endBackgroundTask(_ identifier: UIBackgroundTaskIdentifier) {
-        UIApplication.shared.endBackgroundTask(identifier)
-        backgroundTaskIdentifiers.remove(identifier)
     }
     
     func takeOffline(map: AGSMap, extent: AGSEnvelope) {

--- a/Toolkit/ArcGISToolkit/JobManager.swift
+++ b/Toolkit/ArcGISToolkit/JobManager.swift
@@ -13,7 +13,6 @@
 
 import ArcGIS
 import Foundation
-import BackgroundTasks
 
 internal typealias JSONDictionary = [String: Any]
 public typealias JobStatusHandler = (AGSJobStatus) -> Void
@@ -93,9 +92,6 @@ public class JobManager: NSObject {
     
     deinit {
         keyedJobs.values.forEach { unObserveJobStatus(job: $0) }
-        if let observer = bgObserver {
-            NotificationCenter.default.removeObserver(observer)
-        }
     }
     
     private func toJSON() -> JSONDictionary {
@@ -202,7 +198,7 @@ public class JobManager: NSObject {
     /// - Parameters:
     ///   - application:  See [Apple's documentation](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623125-application)
     ///   - completionHandler:  See [Apple's documentation](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623125-application)
-    @available(iOS, deprecated: 13.0, message: "Please use 'registerForBackgroundUpdates()' instead")
+    @available(iOS, deprecated: 13.0, message: "Please use 'UIApplication.shared.beginBackgroundTask(expirationHandler:)' when kicking off your job instead")
     public func application(application: UIApplication, performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
         if keyedJobs.isEmpty {
             return completionHandler(.noData)
@@ -214,60 +210,6 @@ public class JobManager: NSObject {
                     completionHandler(.failed)
                 }
             }
-        }
-    }
-    
-    private let bgTaskIdentifier = "com.esri.arcgis.toolkit.jobmanager.refresh"
-    private var bgObserver: AnyObject?
-    
-    /// Registers a task for updating job status in the background.
-    /// You must add an entry in the app plist for com.esri.arcgis.toolkit.jobmanager.refresh under BGTaskSchedulerPermittedIdentifiers.
-    /// This must be called before the end of the app launch sequence.
-    /// This must be tested on device, does not work on the simulator. For debugging this, see documentation here: https://developer.apple.com/documentation/backgroundtasks/starting_and_terminating_tasks_during_development?language=objc
-    /// Returns whether or not the registration was successful. If the registration was not successful, please check your application's plist for the appropriately entry
-    /// as mentioned above.
-    @available(iOS 13.0, *)
-    @discardableResult
-    public func registerForBackgroundUpdates() -> Bool {
-        // register the bg task
-        let result = BGTaskScheduler.shared.register(forTaskWithIdentifier: bgTaskIdentifier, using: nil) { [weak self] task in
-            self?.handleBackgroundRefresh(task: task as! BGAppRefreshTask)
-        }
-        
-        // schedule a notification when application enters background
-        if bgObserver == nil {
-            bgObserver = NotificationCenter.default.addObserver(forName: UIApplication.willResignActiveNotification, object: nil, queue: .main) { [weak self] _ in
-                self?.scheduleNextBackgroundRefresh()
-            }
-        }
-        
-        return result
-    }
-    
-    @available(iOS 13.0, *)
-    private func handleBackgroundRefresh(task: BGAppRefreshTask) {
-        // Schedule next refresh
-        scheduleNextBackgroundRefresh()
-        
-        // check job status
-        let operation = JobManager.shared.checkStatusForAllJobs { success in
-            task.setTaskCompleted(success: success)
-        }
-        
-        task.expirationHandler = {
-            operation.cancel()
-        }
-    }
-    
-    @available(iOS 13.0, *)
-    private func scheduleNextBackgroundRefresh() {
-        let request = BGAppRefreshTaskRequest(identifier: bgTaskIdentifier)
-        request.earliestBeginDate = Date(timeIntervalSinceNow: 30)
-        
-        do {
-            try BGTaskScheduler.shared.submit(request)
-        } catch {
-            print("Could not schedule app refresh: \(error)")
         }
     }
     


### PR DESCRIPTION
After speaking with Eric on the apps team. The way the apps team uses `UIApplication.shared.beginBackgroundTask` instead of the background fetch stuff. Background fetch can take hours to get called according to the Apple documentation. Instead `beginBackgroundTask` keeps the app alive for up to 10 minutes, giving most jobs the ability to finish or at least get to the out of process download phase.