### PR TITLE
Fix doc links for GitHub

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,12 +1,12 @@
 ### Table of Contents
 
-* [Augmented reality (AR)](AR/readme) - Integrates the scene view with ARKit to enable augmented reality (AR).
-* [Bookmarks](Bookmarks/readme) - Shows bookmarks, from a map, scene, or a list.
-* [Compass](Compass/readme) - Shows a compass direction when the map is rotated. Auto-hides when the map points north up.
-* [JobManager](JobManager/readme) - Suspends and resumes ArcGIS Runtime tasks when the app is background, terminated, and relaunched.
-* [LegendViewController](LegendViewController/readme) - Displays a legend for all the layers in a map or scene contained in an `AGSGeoView`.
-* [MeasureToolbar](MeasureToolbar/readme) - Allows measurement of distances and areas on the map view.
-* [PopupController](PopupController/readme) - Display details and media, edit attributes, geometry and related records, and manage the attachments of features and graphics (popups are defined in the popup property of features and graphics).
-* [Scalebar](Scalebar/readme) - Displays current scale reference.
-* [TemplatePickerViewController](TemplatePicker/readme) - Allows a user to choose a template from a list of `AGSFeatureTemplate` when creating new features.
-* [TimeSlider](TimeSlider/readme) - Allows interactively defining a temporal range (i.e. time extent) and animating time moving forward or backward. Can be used to manipulate the time extent in a MapView or SceneView.
+* [Augmented reality (AR)](AR) - Integrates the scene view with ARKit to enable augmented reality (AR).
+* [Bookmarks](Bookmarks) - Shows bookmarks, from a map, scene, or a list.
+* [Compass](Compass) - Shows a compass direction when the map is rotated. Auto-hides when the map points north up.
+* [JobManager](JobManager) - Suspends and resumes ArcGIS Runtime tasks when the app is background, terminated, and relaunched.
+* [LegendViewController](LegendViewController) - Displays a legend for all the layers in a map or scene contained in an `AGSGeoView`.
+* [MeasureToolbar](MeasureToolbar) - Allows measurement of distances and areas on the map view.
+* [PopupController](PopupController) - Display details and media, edit attributes, geometry and related records, and manage the attachments of features and graphics (popups are defined in the popup property of features and graphics).
+* [Scalebar](Scalebar) - Displays current scale reference.
+* [TemplatePickerViewController](TemplatePicker) - Allows a user to choose a template from a list of `AGSFeatureTemplate` when creating new features.
+* [TimeSlider](TimeSlider) - Allows interactively defining a temporal range (i.e. time extent) and animating time moving forward or backward. Can be used to manipulate the time extent in a MapView or SceneView.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ArcGIS Runtime Toolkit for iOS
 
-[![doc](https://img.shields.io/badge/Doc-purple)](Documentation/readme) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage) [![CocoaPods](https://img.shields.io/cocoapods/v/ArcGIS-Runtime-Toolkit-iOS)](https://cocoapods.org/)
+[![doc](https://img.shields.io/badge/Doc-purple)](Documentation) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage) [![CocoaPods](https://img.shields.io/cocoapods/v/ArcGIS-Runtime-Toolkit-iOS)](https://cocoapods.org/)
 
 The ArcGIS Runtime SDK for iOS Toolkit contains components that will simplify your iOS app development. Check out the [Examples](/Examples) project to see these components in action or read through the [Documentation](/Documentation) to learn more about them.
 


### PR DESCRIPTION
Oops! links as they were only worked in VS Code. New links don't work in vs code, but have the right behavior on GitHub