### PR TITLE
Update ArcGISARView.swift

### DIFF
--- a/Toolkit/ArcGISToolkit/AR/ArcGISARView.swift
+++ b/Toolkit/ArcGISToolkit/AR/ArcGISARView.swift
@@ -48,7 +48,7 @@ public class ArcGISARView: UIView {
 
     /// The data source used to get device location.  Used either in conjuction with ARKit data or when ARKit is not present or not being used.
     /// - Since: 100.6.0
-    public var locationDataSource: AGSCLLocationDataSource? {
+    public var locationDataSource: AGSLocationDataSource? {
         didSet {
             locationDataSource?.locationChangeHandlerDelegate = self
         }


### PR DESCRIPTION
Make `locationDataSource` conform to `AGSLocationDataSource` to make it possible to inject a mock `locationDataSource` for testing.

It is briefly mentioned here: https://github.com/Esri/arcgis-runtime-toolkit-ios/pull/57

> might be replaced by an AGSLocationDataSource; there is a pending design issue to make the necessary changes to that class in order to support what's necessary for AR (and other use cases).

I think it is time to do so, no need to restrict it to `AGSCLLocationDataSource`, because the fix on line 496 will still work if a `AGSCLLocationDataSource` is used as a `locationDataSource`:
`if let clLocationDataSource = locationDataSource as? AGSCLLocationDataSource {`