### PR TITLE
Fix unused_closure_parameter violations

### DIFF
--- a/Toolkit/ArcGISToolkit/LegendViewController.swift
+++ b/Toolkit/ArcGISToolkit/LegendViewController.swift
@@ -38,7 +38,7 @@ public class LegendViewController: UIViewController, UITableViewDelegate, UITabl
                 
                 //set layerViewStateChangedHandler
                 if let geoView = geoView {
-                    geoView.layerViewStateChangedHandler = { [weak self] (layer: AGSLayer, layerViewState: AGSLayerViewState) in
+                    geoView.layerViewStateChangedHandler = { [weak self] (_, _) in
                         DispatchQueue.main.async {
                             self?.updateLegendArray()
                         }


### PR DESCRIPTION
Addresses a couple linting issues that showed up after upgrading to SwiftLint [0.41.0](https://github.com/realm/SwiftLint/releases/tag/0.41.0).

![Screen Shot 2020-11-16 at 3 41 42 PM](https://user-images.githubusercontent.com/2257493/99321413-9cd2ec80-2822-11eb-9624-8154b7442fd2.png)