### PR TITLE
Update extent for offline map to prevent maxing out tile limit.

### DIFF
--- a/Examples/ArcGISToolkitExamples/JobManagerExample.swift
+++ b/Examples/ArcGISToolkitExamples/JobManagerExample.swift
@@ -218,7 +218,7 @@ class JobManagerExample: TableViewController {
             let portalItem = AGSPortalItem(url: URL(string: "https://www.arcgis.com/home/item.html?id=acc027394bc84c2fb04d1ed317aac674")!)!
             let map = AGSMap(item: portalItem)
             // naperville
-            let env = AGSEnvelope(xMin: -9825684.031125, yMin: 5102237.935062, xMax: -9798254.961608, yMax: 5151000.725314, spatialReference: AGSSpatialReference.webMercator())
+            let env = AGSEnvelope(xMin: -9813416.487598, yMin: 5126112.596989, xMax: -9812775.435463, yMax: 5127101.526749, spatialReference: AGSSpatialReference.webMercator())
             takeOffline(map: map, extent: env)
         }
         


### PR DESCRIPTION
The current area-of-interest extent for the offline map task in the JobManager example is giving an error:
`Export tile cache: Failed: "Job error 6 Illegal state. Server job has failed. ERROR 001564: Requested tile count(1225884) exceeds the maximum allowed number of tiles(150000) to be exported for service World_Street_Map:MapServer. "`

This PR tightens up the extent so less tiles are generated and now the example is not generating an error.

On a map, the new extent looks like this:

![image](https://user-images.githubusercontent.com/3998072/105766084-e9bbf900-5f1e-11eb-8a55-aaf9a26c02ff.png)
