### PR TITLE
Autocorrect violations of comment_spacing

### DIFF
--- a/Toolkit/ArcGISToolkit/LegendViewController.swift
+++ b/Toolkit/ArcGISToolkit/LegendViewController.swift
@@ -36,7 +36,7 @@ public class LegendViewController: UIViewController, UITableViewDelegate, UITabl
                     })
                 }
                 
-                //set layerViewStateChangedHandler
+                // set layerViewStateChangedHandler
                 if let geoView = geoView {
                     geoView.layerViewStateChangedHandler = { [weak self] (_, _) in
                         DispatchQueue.main.async {
@@ -270,7 +270,7 @@ public class LegendViewController: UIViewController, UITableViewDelegate, UITabl
         } else {
             // fetch the legend infos
             layerContent.fetchLegendInfos { [weak self] (legendInfos, _) in
-                //handle legendInfos
+                // handle legendInfos
                 self?.legendInfos[LegendViewController.objectIdentifierFor(layerContent)] = legendInfos
                 self?.updateLegendArray()
             }
@@ -292,7 +292,7 @@ public class LegendViewController: UIViewController, UITableViewDelegate, UITabl
                 // if we're respecting the scale range, make sure our layerContent is in scale
                 if let viewpoint = geoView?.currentViewpoint(with: .centerAndScale) {
                     if !viewpoint.targetScale.isNaN {
-                        //if targetScale is not NAN (i.e., is valid...)
+                        // if targetScale is not NAN (i.e., is valid...)
                         showAtScale = layerContent.isVisible(atScale: viewpoint.targetScale)
                     }
                 }

--- a/Toolkit/ArcGISToolkit/MeasureToolbar.swift
+++ b/Toolkit/ArcGISToolkit/MeasureToolbar.swift
@@ -513,7 +513,7 @@ public class MeasureToolbar: UIToolbar, AGSGeoViewTouchDelegate {
             planar = linearUnit.convert(toMeters: planar)
             if planar > planarLengthMetersThreshold {
                 let planarDisplay = AGSLinearUnit.meters().convert(planar, to: selectedLinearUnit)
-                //`print("returning planar length... \(planar) sq meters")
+                // `print("returning planar length... \(planar) sq meters")
                 return planarDisplay
             }
         }
@@ -537,7 +537,7 @@ public class MeasureToolbar: UIToolbar, AGSGeoViewTouchDelegate {
             if let planarMiles = linearUnit.toAreaUnit()?.convert(planar, to: AGSAreaUnit.squareMiles()),
                 planarMiles > planarAreaSquareMilesThreshold {
                 let planarDisplay = AGSAreaUnit.squareMiles().convert(planarMiles, to: selectedAreaUnit)
-                //print("returning planar area... \(planarMiles) sq miles")
+                // print("returning planar area... \(planarMiles) sq miles")
                 return planarDisplay
             }
         }

--- a/Toolkit/ArcGISToolkit/Scalebar.swift
+++ b/Toolkit/ArcGISToolkit/Scalebar.swift
@@ -381,10 +381,10 @@ public class Scalebar: UIView {
             return
         }
         
-        //print("current scale: \(mapView.mapScale)")
+        // print("current scale: \(mapView.mapScale)")
         
         guard minScale <= 0 || mapView.mapScale < minScale else {
-            //print("current scale: \(mapView.mapScale), minScale \(minScale)")
+            // print("current scale: \(mapView.mapScale), minScale \(minScale)")
             renderer.currentScaleDisplay = nil
             setNeedsDisplay()
             return
@@ -450,7 +450,7 @@ public class Scalebar: UIView {
         let mapLengthString = Scalebar.numberFormatter.string(from: NSNumber(value: lineMapLength)) ?? ""
         renderer.currentScaleDisplay = ScaleDisplay(mapScale: mapScale, unitsPerPoint: unitsPerPoint, lineMapLength: lineMapLength, displayUnit: displayUnit, lineDisplayLength: lineDisplayLength, mapCenter: mapCenter, mapLengthString: mapLengthString)
         
-        //print("geodetic: \(useGeodeticCalculations), lineDisplayLength: \(numberFormatter.string(from: lineDisplayLength as NSNumber)!), mapLength: \(lineMapLength) \(displayUnit.abbreviation))")
+        // print("geodetic: \(useGeodeticCalculations), lineDisplayLength: \(numberFormatter.string(from: lineDisplayLength as NSNumber)!), mapLength: \(lineMapLength) \(displayUnit.abbreviation))")
         
         // invalidate intrinsic content size
         invalidateIntrinsicContentSize()


### PR DESCRIPTION
The `comment_spacing` [rule](https://realm.github.io/SwiftLint/comment_spacing.html) was added in SwiftLint [0.42.0](https://github.com/realm/SwiftLint/releases/tag/0.42.0). This PR corrects all violations of it by running `swiftlint autocorrect`.