### PR TITLE
Edit scalebar README

### DIFF
--- a/Documentation/Scalebar/README.md
+++ b/Documentation/Scalebar/README.md
@@ -11,7 +11,7 @@ The scalebar uses geodetic calculations to provide accurate measurements for map
         scalebar.style = .alternatingBar
         scalebar.units = .metric
         scalebar.alignment = .left
-        view.addSubview(sb)
+        view.addSubview(scalebar)
 ```
 
 To see it in action, try out the [Examples](../../Examples) and refer to [ScalebarExample.swift](../../Examples/ArcGISToolkitExamples/ScalebarExample.swift) in the project.


### PR DESCRIPTION
For this piece of code in the scalebar README, the variable is declared as `scalebar`, not `sb`.