### PR TITLE
Add Toolkit Project 

### DIFF
--- a/ArcGISToolkit.xcodeproj/project.pbxproj
+++ b/ArcGISToolkit.xcodeproj/project.pbxproj
@@ -27,22 +27,7 @@
 		799DBBE8261BC1AE006B61DC /* MeasureToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799DBBD5261BC1AE006B61DC /* MeasureToolbar.swift */; };
 		799DBBE9261BC1AE006B61DC /* Compass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799DBBD6261BC1AE006B61DC /* Compass.swift */; };
 		799DBBED261BC1DC006B61DC /* ArcGIS.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 799DBBEC261BC1DC006B61DC /* ArcGIS.xcframework */; };
-		799DBBEE261BC1DC006B61DC /* ArcGIS.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 799DBBEC261BC1DC006B61DC /* ArcGIS.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
-
-/* Begin PBXCopyFilesBuildPhase section */
-		799DBBEF261BC1DC006B61DC /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				799DBBEE261BC1DC006B61DC /* ArcGIS.xcframework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		799DBBAC261BC004006B61DC /* ArcGISToolkit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ArcGISToolkit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -176,7 +161,6 @@
 				799DBBA8261BC004006B61DC /* Sources */,
 				799DBBA9261BC004006B61DC /* Frameworks */,
 				799DBBAA261BC004006B61DC /* Resources */,
-				799DBBEF261BC1DC006B61DC /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/ArcGISToolkit.xcodeproj/project.pbxproj
+++ b/ArcGISToolkit.xcodeproj/project.pbxproj
@@ -1,0 +1,459 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 52;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		799DBBD7261BC1AE006B61DC /* JobManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799DBBC2261BC1AE006B61DC /* JobManager.swift */; };
+		799DBBD8261BC1AE006B61DC /* BookmarksViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799DBBC3261BC1AE006B61DC /* BookmarksViewController.swift */; };
+		799DBBD9261BC1AE006B61DC /* UnitsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799DBBC4261BC1AE006B61DC /* UnitsViewController.swift */; };
+		799DBBDA261BC1AE006B61DC /* LegendViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799DBBC5261BC1AE006B61DC /* LegendViewController.swift */; };
+		799DBBDB261BC1AE006B61DC /* CancelGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799DBBC6261BC1AE006B61DC /* CancelGroup.swift */; };
+		799DBBDC261BC1AE006B61DC /* MapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799DBBC7261BC1AE006B61DC /* MapViewController.swift */; };
+		799DBBDD261BC1AE006B61DC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 799DBBC9261BC1AE006B61DC /* Assets.xcassets */; };
+		799DBBDE261BC1AE006B61DC /* Legend.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 799DBBCA261BC1AE006B61DC /* Legend.storyboard */; };
+		799DBBDF261BC1AE006B61DC /* Coalescer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799DBBCB261BC1AE006B61DC /* Coalescer.swift */; };
+		799DBBE0261BC1AE006B61DC /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799DBBCC261BC1AE006B61DC /* Extensions.swift */; };
+		799DBBE1261BC1AE006B61DC /* BookmarksTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799DBBCD261BC1AE006B61DC /* BookmarksTableViewController.swift */; };
+		799DBBE2261BC1AE006B61DC /* TemplatePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799DBBCE261BC1AE006B61DC /* TemplatePickerViewController.swift */; };
+		799DBBE3261BC1AE006B61DC /* PopupController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799DBBCF261BC1AE006B61DC /* PopupController.swift */; };
+		799DBBE4261BC1AE006B61DC /* TableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799DBBD0261BC1AE006B61DC /* TableViewController.swift */; };
+		799DBBE5261BC1AE006B61DC /* Scalebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799DBBD1261BC1AE006B61DC /* Scalebar.swift */; };
+		799DBBE6261BC1AE006B61DC /* ArcGISARView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799DBBD3261BC1AE006B61DC /* ArcGISARView.swift */; };
+		799DBBE7261BC1AE006B61DC /* TimeSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799DBBD4261BC1AE006B61DC /* TimeSlider.swift */; };
+		799DBBE8261BC1AE006B61DC /* MeasureToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799DBBD5261BC1AE006B61DC /* MeasureToolbar.swift */; };
+		799DBBE9261BC1AE006B61DC /* Compass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799DBBD6261BC1AE006B61DC /* Compass.swift */; };
+		799DBBED261BC1DC006B61DC /* ArcGIS.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 799DBBEC261BC1DC006B61DC /* ArcGIS.xcframework */; };
+		799DBBEE261BC1DC006B61DC /* ArcGIS.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 799DBBEC261BC1DC006B61DC /* ArcGIS.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		799DBBEF261BC1DC006B61DC /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				799DBBEE261BC1DC006B61DC /* ArcGIS.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		799DBBAC261BC004006B61DC /* ArcGISToolkit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ArcGISToolkit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		799DBBC2261BC1AE006B61DC /* JobManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JobManager.swift; sourceTree = "<group>"; };
+		799DBBC3261BC1AE006B61DC /* BookmarksViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksViewController.swift; sourceTree = "<group>"; };
+		799DBBC4261BC1AE006B61DC /* UnitsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnitsViewController.swift; sourceTree = "<group>"; };
+		799DBBC5261BC1AE006B61DC /* LegendViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegendViewController.swift; sourceTree = "<group>"; };
+		799DBBC6261BC1AE006B61DC /* CancelGroup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CancelGroup.swift; sourceTree = "<group>"; };
+		799DBBC7261BC1AE006B61DC /* MapViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapViewController.swift; sourceTree = "<group>"; };
+		799DBBC9261BC1AE006B61DC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		799DBBCA261BC1AE006B61DC /* Legend.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Legend.storyboard; sourceTree = "<group>"; };
+		799DBBCB261BC1AE006B61DC /* Coalescer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Coalescer.swift; sourceTree = "<group>"; };
+		799DBBCC261BC1AE006B61DC /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
+		799DBBCD261BC1AE006B61DC /* BookmarksTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksTableViewController.swift; sourceTree = "<group>"; };
+		799DBBCE261BC1AE006B61DC /* TemplatePickerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TemplatePickerViewController.swift; sourceTree = "<group>"; };
+		799DBBCF261BC1AE006B61DC /* PopupController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PopupController.swift; sourceTree = "<group>"; };
+		799DBBD0261BC1AE006B61DC /* TableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewController.swift; sourceTree = "<group>"; };
+		799DBBD1261BC1AE006B61DC /* Scalebar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Scalebar.swift; sourceTree = "<group>"; };
+		799DBBD3261BC1AE006B61DC /* ArcGISARView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArcGISARView.swift; sourceTree = "<group>"; };
+		799DBBD4261BC1AE006B61DC /* TimeSlider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeSlider.swift; sourceTree = "<group>"; };
+		799DBBD5261BC1AE006B61DC /* MeasureToolbar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MeasureToolbar.swift; sourceTree = "<group>"; };
+		799DBBD6261BC1AE006B61DC /* Compass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Compass.swift; sourceTree = "<group>"; };
+		799DBBEC261BC1DC006B61DC /* ArcGIS.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = ArcGIS.xcframework; path = $HOME/Library/SDKs/ArcGIS/Frameworks/ArcGIS.xcframework; sourceTree = "<absolute>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		799DBBA9261BC004006B61DC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				799DBBED261BC1DC006B61DC /* ArcGIS.xcframework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		799DBBA2261BC004006B61DC = {
+			isa = PBXGroup;
+			children = (
+				799DBBC0261BC1AE006B61DC /* Sources */,
+				799DBBAD261BC004006B61DC /* Products */,
+				799DBBEB261BC1DC006B61DC /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		799DBBAD261BC004006B61DC /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				799DBBAC261BC004006B61DC /* ArcGISToolkit.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		799DBBC0261BC1AE006B61DC /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				799DBBC1261BC1AE006B61DC /* ArcGISToolkit */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		799DBBC1261BC1AE006B61DC /* ArcGISToolkit */ = {
+			isa = PBXGroup;
+			children = (
+				799DBBC2261BC1AE006B61DC /* JobManager.swift */,
+				799DBBC3261BC1AE006B61DC /* BookmarksViewController.swift */,
+				799DBBC4261BC1AE006B61DC /* UnitsViewController.swift */,
+				799DBBC5261BC1AE006B61DC /* LegendViewController.swift */,
+				799DBBC6261BC1AE006B61DC /* CancelGroup.swift */,
+				799DBBC7261BC1AE006B61DC /* MapViewController.swift */,
+				799DBBC8261BC1AE006B61DC /* Resources */,
+				799DBBCB261BC1AE006B61DC /* Coalescer.swift */,
+				799DBBCC261BC1AE006B61DC /* Extensions.swift */,
+				799DBBCD261BC1AE006B61DC /* BookmarksTableViewController.swift */,
+				799DBBCE261BC1AE006B61DC /* TemplatePickerViewController.swift */,
+				799DBBCF261BC1AE006B61DC /* PopupController.swift */,
+				799DBBD0261BC1AE006B61DC /* TableViewController.swift */,
+				799DBBD1261BC1AE006B61DC /* Scalebar.swift */,
+				799DBBD2261BC1AE006B61DC /* AR */,
+				799DBBD4261BC1AE006B61DC /* TimeSlider.swift */,
+				799DBBD5261BC1AE006B61DC /* MeasureToolbar.swift */,
+				799DBBD6261BC1AE006B61DC /* Compass.swift */,
+			);
+			path = ArcGISToolkit;
+			sourceTree = "<group>";
+		};
+		799DBBC8261BC1AE006B61DC /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				799DBBC9261BC1AE006B61DC /* Assets.xcassets */,
+				799DBBCA261BC1AE006B61DC /* Legend.storyboard */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		799DBBD2261BC1AE006B61DC /* AR */ = {
+			isa = PBXGroup;
+			children = (
+				799DBBD3261BC1AE006B61DC /* ArcGISARView.swift */,
+			);
+			path = AR;
+			sourceTree = "<group>";
+		};
+		799DBBEB261BC1DC006B61DC /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				799DBBEC261BC1DC006B61DC /* ArcGIS.xcframework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		799DBBA7261BC004006B61DC /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		799DBBAB261BC004006B61DC /* ArcGISToolkit */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 799DBBB4261BC004006B61DC /* Build configuration list for PBXNativeTarget "ArcGISToolkit" */;
+			buildPhases = (
+				799DBBA7261BC004006B61DC /* Headers */,
+				799DBBA8261BC004006B61DC /* Sources */,
+				799DBBA9261BC004006B61DC /* Frameworks */,
+				799DBBAA261BC004006B61DC /* Resources */,
+				799DBBEF261BC1DC006B61DC /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ArcGISToolkit;
+			productName = ArcGISToolkit;
+			productReference = 799DBBAC261BC004006B61DC /* ArcGISToolkit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		799DBBA3261BC004006B61DC /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1200;
+				TargetAttributes = {
+					799DBBAB261BC004006B61DC = {
+						CreatedOnToolsVersion = 12.0;
+					};
+				};
+			};
+			buildConfigurationList = 799DBBA6261BC004006B61DC /* Build configuration list for PBXProject "ArcGISToolkit" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 799DBBA2261BC004006B61DC;
+			productRefGroup = 799DBBAD261BC004006B61DC /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				799DBBAB261BC004006B61DC /* ArcGISToolkit */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		799DBBAA261BC004006B61DC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				799DBBDD261BC1AE006B61DC /* Assets.xcassets in Resources */,
+				799DBBDE261BC1AE006B61DC /* Legend.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		799DBBA8261BC004006B61DC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				799DBBDB261BC1AE006B61DC /* CancelGroup.swift in Sources */,
+				799DBBE3261BC1AE006B61DC /* PopupController.swift in Sources */,
+				799DBBDC261BC1AE006B61DC /* MapViewController.swift in Sources */,
+				799DBBD8261BC1AE006B61DC /* BookmarksViewController.swift in Sources */,
+				799DBBE8261BC1AE006B61DC /* MeasureToolbar.swift in Sources */,
+				799DBBE0261BC1AE006B61DC /* Extensions.swift in Sources */,
+				799DBBE2261BC1AE006B61DC /* TemplatePickerViewController.swift in Sources */,
+				799DBBE9261BC1AE006B61DC /* Compass.swift in Sources */,
+				799DBBE6261BC1AE006B61DC /* ArcGISARView.swift in Sources */,
+				799DBBE5261BC1AE006B61DC /* Scalebar.swift in Sources */,
+				799DBBD9261BC1AE006B61DC /* UnitsViewController.swift in Sources */,
+				799DBBE4261BC1AE006B61DC /* TableViewController.swift in Sources */,
+				799DBBE1261BC1AE006B61DC /* BookmarksTableViewController.swift in Sources */,
+				799DBBDF261BC1AE006B61DC /* Coalescer.swift in Sources */,
+				799DBBD7261BC1AE006B61DC /* JobManager.swift in Sources */,
+				799DBBDA261BC1AE006B61DC /* LegendViewController.swift in Sources */,
+				799DBBE7261BC1AE006B61DC /* TimeSlider.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		799DBBB2261BC004006B61DC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		799DBBB3261BC004006B61DC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		799DBBB5261BC004006B61DC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 100.11;
+				PRODUCT_BUNDLE_IDENTIFIER = com.esri.ArcGISToolkit;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		799DBBB6261BC004006B61DC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 100.11;
+				PRODUCT_BUNDLE_IDENTIFIER = com.esri.ArcGISToolkit;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		799DBBA6261BC004006B61DC /* Build configuration list for PBXProject "ArcGISToolkit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				799DBBB2261BC004006B61DC /* Debug */,
+				799DBBB3261BC004006B61DC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		799DBBB4261BC004006B61DC /* Build configuration list for PBXNativeTarget "ArcGISToolkit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				799DBBB5261BC004006B61DC /* Debug */,
+				799DBBB6261BC004006B61DC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 799DBBA3261BC004006B61DC /* Project object */;
+}

--- a/ArcGISToolkit.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ArcGISToolkit.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ArcGISToolkit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ArcGISToolkit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ The *ArcGIS Runtime Toolkit for iOS* has a *Target SDK* version of *13.0*, meani
 
 ### Manual
 
- 1. Clone or download this repo
- 2. Drag and Drop the `arcgis-runtime-toolkit-ios` folder into your project through the Xcode Project Navigator pane
- 3. Add the *ArcGISToolkit* library in your app, by adding it to the Frameworks, Libraries, and Embedded Content section of the General pane for your app target. The *ArcGISToolkit* library contains the *ArcGIS Runtime SDK for iOS* library, so you don't need to add that separately.
- 4. Add `import ArcGIS` and `import ArcGISToolkit` in your source code and start using the toolkit components 
+ 1. Ensure you have downloaded and installed __ArcGIS Runtime SDK for iOS__ as described [here](https://developers.arcgis.com/ios/get-started/)
+ 2. Clone or download this repo
+ 3. Drag and Drop the `ArcGISToolkit.xcodeproj` file into your project through the XCode Project Navigator pane
+ 4. Drag the `ArcGISToolkit.framework` from the `ArcGISToolkit.xcodeproj/ArcGISToolkit/Products` folder to the "TARGETS" settings for your application and drop it in the "Embedded Binaries" section in the "General" tab
+ 5. Add `import ArcGISToolkit` in your source code and start using the toolkit components 
 
 Note: Support for Carthage as been dropped for v100.11.0.
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ The *ArcGIS Runtime Toolkit for iOS* has a *Target SDK* version of *13.0*, meani
 ### Manual
 
  1. Ensure you have downloaded and installed __ArcGIS Runtime SDK for iOS__ as described [here](https://developers.arcgis.com/ios/get-started/)
- 2. Clone or download this repo
- 3. Drag and Drop the `ArcGISToolkit.xcodeproj` file into your project through the XCode Project Navigator pane
- 4. Drag the `ArcGISToolkit.framework` from the `ArcGISToolkit.xcodeproj/ArcGISToolkit/Products` folder to the "TARGETS" settings for your application and drop it in the "Embedded Binaries" section in the "General" tab
+ 2. Clone or download this repository
+ 3. Drag and Drop the `ArcGISToolkit.xcodeproj` file into your project through the Xcode Project Navigator pane
+ 4. Under "Frameworks, Libraries, and Embedded Content" click on the + and choose `ArcGISToolkit.framework`
  5. Add `import ArcGISToolkit` in your source code and start using the toolkit components 
 
 Note: Support for Carthage as been dropped for v100.11.0.

--- a/Sources/ArcGISToolkit/Extensions.swift
+++ b/Sources/ArcGISToolkit/Extensions.swift
@@ -32,8 +32,17 @@ extension UIApplication {
 }
 
 #if !SWIFT_PACKAGE
-// This is a workaround for cocoapods compatibility.
+// This is a workaround for installing the toolkit using the project file or cocoapods.
 extension Bundle {
-    static var module: Bundle { Bundle(identifier: "org.cocoapods.ArcGISToolkit")! }
+    static var module: Bundle {
+        var validModule: Bundle
+        // Toolkit was installed using project file.
+        if let module = Bundle(identifier: "com.esri.ArcGISToolkit") {
+            validModule = module
+        } else { // Toolkit was installed using cocoapods.
+            validModule = Bundle(identifier: "org.cocoapods.ArcGISToolkit")!
+        }
+        return validModule
+    }
 }
 #endif


### PR DESCRIPTION
Reasons for adding a usable toolkit project
- For internal reasons
- If users still wanna use the toolkit with the manually installed SDK

Let me know your thoughts if the project file  (and `info.plist`) should be in its own folder (maybe ArcGISToolkitProject/). Right now it is at the root of the repo. (Ting showed me an example that left the project file and .plist at the root)

Cc: @dg0yal @yo1995 