### PR TITLE
Update package manifest for U12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/Esri/arcgis-runtime-ios", .upToNextMinor(from: "100.11.0"))
+        .package(url: "https://github.com/Esri/arcgis-runtime-ios", .upToNextMinor(from: "100.12.0"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
Update 12 is not available for the SDK yet so heads up this will show an error. We don't need to merge this now but it should be ready to merge when we need to.