### PR TITLE
Fully set up the "siteFacilityPromptVC" before display.

### DIFF
--- a/Sources/ArcGISToolkit/FloorFilter/FloorFilterViewController.swift
+++ b/Sources/ArcGISToolkit/FloorFilter/FloorFilterViewController.swift
@@ -278,9 +278,9 @@ public class FloorFilterViewController: UIViewController, FloorFilterViewControl
         // Only show the prompt if there sites or facilities data
         let siteFacilityPromptVC = storyboard!.instantiateViewController(identifier: "SiteFacilityPromptVC") as! SiteFacilityPromptViewController
         siteFacilityPromptVC.modalPresentationStyle = .automatic
-        present(siteFacilityPromptVC, animated: true)
         siteFacilityPromptVC.delegate = self
         siteFacilityPromptVC.viewModel = viewModel
+        present(siteFacilityPromptVC, animated: true)
     }
     
     @objc func collapseLevelsList(sender: UIButton) {


### PR DESCRIPTION
Fix a crash in the `siteFacilityPromptVC`.  The issue is that the view model was being set on the VC __after__ the VC was displayed.  This resulted in an incorrect initialization of the `filteredSearchFacilities` variable, which caused a crash in the `tableView(tableView:, didSelectRowAt:)` method.

Steps to reproduce:
- open FF example
- tap on "Sites" button
- tap on "Redlands Main"
- tap on "Building L" to select
- [map is displayed on Building L]
- tap on "Sites" button
- tap on "Redlands Main"
- tap on "filter" search bar to make the text field the first responder
- tap on "Building L".

Because `filteredSearchFacilities` was setup incorrectly (it has no elements), the code in `didSelectRowAt:` crashes with an "Index out of range" error.

The fix is to fully set up the `siteFacilityPromptVC` before displaying it.
