### PR TITLE
Add Privacy Manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -52,7 +52,10 @@ let package = Package(
     targets: [
         .target(
             name: "ArcGISToolkit",
-            dependencies: [.product(name: "ArcGIS", package: "arcgis-runtime-ios")]
+            dependencies: [.product(name: "ArcGIS", package: "arcgis-runtime-ios")],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy")
+            ]
         ),
         .testTarget(
             name: "ArcGISToolkitTests",

--- a/Sources/ArcGISToolkit/PrivacyInfo.xcprivacy
+++ b/Sources/ArcGISToolkit/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+    </array>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+</dict>
+</plist>


### PR DESCRIPTION
Swift issue: #5086

These are the things that need to be declared in the privacy manifest if we collect any of this info:
* [Describing data use](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests)
- [Required Use APIs](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api)

I only listed in the privacy manifest that we use user defaults for a qualified reason. I didn't see any other items we need to list.